### PR TITLE
Change sss_map_image to include sss_waterfall_model and ping_duration

### DIFF
--- a/src/bathy_maps/include/bathy_maps/base_draper.h
+++ b/src/bathy_maps/include/bathy_maps/base_draper.h
@@ -69,6 +69,7 @@ protected:
 
 public:
 
+    void set_texture(const Eigen::MatrixXd& texture, const BoundsT& bounds);
     void set_sidescan_yaw(double new_sensor_yaw) { sensor_yaw = new_sensor_yaw; }
     void set_ray_tracing_enabled(bool enabled);
     void set_vehicle_mesh(const Eigen::MatrixXd& new_V2, const Eigen::MatrixXi& new_F2, const Eigen::MatrixXd& new_C2);

--- a/src/bathy_maps/include/bathy_maps/base_draper.h
+++ b/src/bathy_maps/include/bathy_maps/base_draper.h
@@ -45,6 +45,28 @@ protected:
     double sensor_yaw;
     bool ray_tracing_enabled; // is snell ray tracing enabled?
 
+    // NOTE: these are new style functions
+
+    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> project();
+
+    Eigen::VectorXd compute_times(const Eigen::MatrixXd& P);
+
+    Eigen::VectorXd convert_to_time_bins(const Eigen::VectorXd& times, const Eigen::VectorXd& values,
+                                         const xtf_data::xtf_sss_ping_side& ping, size_t nbr_windows);
+
+    Eigen::VectorXd compute_intensities(const Eigen::VectorXd& times, 
+                                        const xtf_data::xtf_sss_ping_side& ping);
+
+    void visualize_rays(const Eigen::MatrixXd& hits_left, const Eigen::MatrixXd& hits_right);
+
+    void visualize_vehicle();
+
+    Eigen::VectorXd compute_model_intensities(const Eigen::MatrixXd& hits, const Eigen::MatrixXd& normals,
+                                              const Eigen::Vector3d& origin);
+
+    // NOTE: these are old style functions, to be deprecated
+    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::VectorXi, Eigen::VectorXi, Eigen::Vector3d> project_sss();
+
 public:
 
     void set_sidescan_yaw(double new_sensor_yaw) { sensor_yaw = new_sensor_yaw; }
@@ -57,7 +79,6 @@ public:
                const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds = csv_data::csv_asvp_sound_speed::EntriesT());
 
     void show();
-    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::VectorXi, Eigen::VectorXi, Eigen::Vector3d> project_sss();
     bool callback_pre_draw(igl::opengl::glfw::Viewer& viewer);
 };
 

--- a/src/bathy_maps/include/bathy_maps/map_draper.h
+++ b/src/bathy_maps/include/bathy_maps/map_draper.h
@@ -28,6 +28,7 @@ protected:
     std::function<void(sss_map_image)> save_callback;
     sss_map_image::ImagesT map_images;
     sss_map_image_builder map_image_builder;
+    Eigen::MatrixXd draping_vis_texture;
 
 public:
     

--- a/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
+++ b/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
@@ -146,6 +146,7 @@ public:
               const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds,
               const Eigen::MatrixXd& height_map);
 
+    bool callback_key_pressed(igl::opengl::glfw::Viewer& viewer, unsigned int key, int mods);
     bool callback_pre_draw(igl::opengl::glfw::Viewer& viewer);
 };
 

--- a/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
+++ b/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
@@ -101,21 +101,22 @@ protected:
     cv::Mat gt_waterfall_image;
     cv::Mat model_waterfall_image;
     Eigen::MatrixXd waterfall_depth;
+    Eigen::MatrixXd waterfall_model;
     size_t waterfall_row;
     size_t resample_window_height;
     size_t full_window_height;
 
     void generate_sss_window();
-    Eigen::VectorXd compute_times(const Eigen::MatrixXd& P);
-    Eigen::VectorXd compute_time_windows(const Eigen::VectorXd& times, const Eigen::VectorXd& intensities, const xtf_data::xtf_sss_ping_side& ping);
-    Eigen::VectorXd compute_depth_windows(const Eigen::VectorXd& times, const Eigen::MatrixXd& hits, const xtf_data::xtf_sss_ping_side& ping);
-    Eigen::VectorXd compute_model_intensities(const Eigen::MatrixXd& hits, const Eigen::MatrixXd& normals,
-                                              const Eigen::Vector3d& origin);
-    void visualize_rays(const Eigen::MatrixXd& hits_left, const Eigen::MatrixXd& hits_right);
-    void visualize_vehicle();
+    //Eigen::VectorXd compute_times(const Eigen::MatrixXd& P);
+    //Eigen::VectorXd compute_time_windows(const Eigen::VectorXd& times, const Eigen::VectorXd& intensities, const xtf_data::xtf_sss_ping_side& ping);
+    //Eigen::VectorXd compute_depth_windows(const Eigen::VectorXd& times, const Eigen::MatrixXd& hits, const xtf_data::xtf_sss_ping_side& ping);
+    //Eigen::VectorXd compute_model_intensities(const Eigen::MatrixXd& hits, const Eigen::MatrixXd& normals,
+    //                                          const Eigen::Vector3d& origin);
+    //void visualize_rays(const Eigen::MatrixXd& hits_left, const Eigen::MatrixXd& hits_right);
+    //void visualize_vehicle();
     Eigen::VectorXd get_texture_intensities(const Eigen::MatrixXd& P);
     Eigen::MatrixXd get_UV(const Eigen::MatrixXd& P);
-    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> project();
+    //std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> project();
     void construct_gt_waterfall();
     void construct_model_waterfall(const Eigen::MatrixXd& hits_left, const Eigen::MatrixXd& hits_right,
                                    const Eigen::MatrixXd& normals_left, const Eigen::MatrixXd& normals_right,

--- a/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
+++ b/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
@@ -106,6 +106,9 @@ protected:
     size_t resample_window_height;
     size_t full_window_height;
 
+    double left_row_mean;
+    double right_row_mean;
+
     void generate_sss_window();
     //Eigen::VectorXd compute_times(const Eigen::MatrixXd& P);
     //Eigen::VectorXd compute_time_windows(const Eigen::VectorXd& times, const Eigen::VectorXd& intensities, const xtf_data::xtf_sss_ping_side& ping);

--- a/src/bathy_maps/include/bathy_maps/sss_map_image.h
+++ b/src/bathy_maps/include/bathy_maps/sss_map_image.h
@@ -77,6 +77,8 @@ public:
 
     sss_map_image_builder(const sss_map_image::BoundsT& bounds, double resolution, int nbr_pings);
 
+    std::pair<int, int> get_map_image_shape();
+
     size_t get_waterfall_bins();
 
     bool empty();

--- a/src/bathy_maps/include/bathy_maps/sss_map_image.h
+++ b/src/bathy_maps/include/bathy_maps/sss_map_image.h
@@ -29,6 +29,7 @@ struct sss_map_image {
 
     Eigen::MatrixXd sss_map_image;
 
+    double sss_ping_duration; // max time in waterfall image
     Eigen::MatrixXf sss_waterfall_image;
     Eigen::MatrixXf sss_waterfall_cross_track;
     Eigen::MatrixXf sss_waterfall_depth;
@@ -39,9 +40,9 @@ struct sss_map_image {
 	template <class Archive>
     void serialize( Archive & ar )
     {
-        ar(CEREAL_NVP(bounds), CEREAL_NVP(sss_map_image), CEREAL_NVP(sss_waterfall_image),
-           CEREAL_NVP(sss_waterfall_cross_track), CEREAL_NVP(sss_waterfall_depth),
-           CEREAL_NVP(sss_waterfall_model), CEREAL_NVP(pos));
+        ar(CEREAL_NVP(bounds), CEREAL_NVP(sss_map_image), CEREAL_NVP(sss_ping_duration),
+           CEREAL_NVP(sss_waterfall_image), CEREAL_NVP(sss_waterfall_cross_track),
+           CEREAL_NVP(sss_waterfall_depth), CEREAL_NVP(sss_waterfall_model), CEREAL_NVP(pos));
     }
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -64,6 +65,7 @@ private:
 
     int waterfall_width;
     int waterfall_counter;
+    double sss_ping_duration; // max time in waterfall image
     Eigen::MatrixXd sss_waterfall_image;
     Eigen::MatrixXd sss_waterfall_cross_track;
     Eigen::MatrixXd sss_waterfall_depth;

--- a/src/bathy_maps/include/bathy_maps/sss_map_image.h
+++ b/src/bathy_maps/include/bathy_maps/sss_map_image.h
@@ -32,6 +32,7 @@ struct sss_map_image {
     Eigen::MatrixXf sss_waterfall_image;
     Eigen::MatrixXf sss_waterfall_cross_track;
     Eigen::MatrixXf sss_waterfall_depth;
+    Eigen::MatrixXf sss_waterfall_model;
 
     std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > pos;
 
@@ -40,7 +41,7 @@ struct sss_map_image {
     {
         ar(CEREAL_NVP(bounds), CEREAL_NVP(sss_map_image), CEREAL_NVP(sss_waterfall_image),
            CEREAL_NVP(sss_waterfall_cross_track), CEREAL_NVP(sss_waterfall_depth),
-           CEREAL_NVP(pos));
+           CEREAL_NVP(sss_waterfall_model), CEREAL_NVP(pos));
     }
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -66,12 +67,15 @@ private:
     Eigen::MatrixXd sss_waterfall_image;
     Eigen::MatrixXd sss_waterfall_cross_track;
     Eigen::MatrixXd sss_waterfall_depth;
+    Eigen::MatrixXd sss_waterfall_model;
 
     std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> > poss;
 
 public:
 
     sss_map_image_builder(const sss_map_image::BoundsT& bounds, double resolution, int nbr_pings);
+
+    size_t get_waterfall_bins();
 
     bool empty();
 
@@ -83,6 +87,10 @@ public:
                               const xtf_data::xtf_sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left);
 
     void add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
+                  const xtf_data::xtf_sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left);
+
+    void add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXd& intensities,
+                  const Eigen::VectorXd& sss_depths, const Eigen::VectorXd& sss_model,
                   const xtf_data::xtf_sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left);
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/bathy_maps/src/base_draper.cpp
+++ b/src/bathy_maps/src/base_draper.cpp
@@ -61,6 +61,24 @@ BaseDraper::BaseDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
     viewer.core.background_color << 1., 1., 1., 1.; // white background
 }
 
+void BaseDraper::set_texture(const Eigen::MatrixXd& texture, const BoundsT& bounds)
+{
+    Eigen::Matrix<unsigned char,Eigen::Dynamic,Eigen::Dynamic> R = (255.*texture.transpose()).cast<uint8_t>();
+    Eigen::Matrix<unsigned char,Eigen::Dynamic,Eigen::Dynamic> G = (255.*texture.transpose()).cast<uint8_t>();
+    Eigen::Matrix<unsigned char,Eigen::Dynamic,Eigen::Dynamic> B = (255.*texture.transpose()).cast<uint8_t>();
+
+    Eigen::MatrixXd UV = V.leftCols<2>();
+    //UV.col(0).array() -= bounds(0, 0);
+    UV.col(0).array() /= bounds(1, 0) - bounds(0, 0);
+    //UV.col(1).array() -= bounds(0, 1);
+    UV.col(1).array() /= bounds(1, 1) - bounds(0, 1);
+
+    viewer.data().set_uv(UV);
+    viewer.data().show_texture = true;
+    // Use the image as a texture
+    viewer.data().set_texture(R, G, B);
+}
+
 void BaseDraper::set_vehicle_mesh(const Eigen::MatrixXd& new_V2, const Eigen::MatrixXi& new_F2, const Eigen::MatrixXd& new_C2)
 {
     V2 = new_V2;
@@ -327,7 +345,8 @@ Eigen::VectorXd BaseDraper::compute_model_intensities(const Eigen::MatrixXd& hit
         dir.normalize();
         Eigen::Vector3d n = normals.row(j).transpose();
         n.normalize();
-        intensities(j) = std::min(fabs(dir.dot(n))*(20./dist), 1.);
+        //intensities(j) = std::min(fabs(dir.dot(n))*(300./(dist*dist)), 1.);
+        intensities(j) = std::min(fabs(dir.dot(n)), 1.);
     }
 
     return intensities;

--- a/src/bathy_maps/src/base_draper.cpp
+++ b/src/bathy_maps/src/base_draper.cpp
@@ -209,3 +209,126 @@ void drape_viewer(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F,
     //viewer.set_ray_tracing_enabled(true);
     viewer.show();
 }
+
+// New style functions follow here:
+tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::project()
+{
+    cout << "Setting new position: " << pings[i].pos_.transpose() << endl;
+    Eigen::Matrix3d Rcomp = Eigen::AngleAxisd(sensor_yaw, Eigen::Vector3d::UnitZ()).matrix();
+    Eigen::Matrix3d Ry = Eigen::AngleAxisd(pings[i].pitch_, Eigen::Vector3d::UnitY()).matrix();
+    Eigen::Matrix3d Rz = Eigen::AngleAxisd(pings[i].heading_, Eigen::Vector3d::UnitZ()).matrix();
+    Eigen::Matrix3d R = Rz*Ry*Rcomp;
+
+    Eigen::MatrixXd hits_left;
+    Eigen::MatrixXd hits_right;
+    Eigen::VectorXi hits_left_inds;
+    Eigen::VectorXi hits_right_inds;
+    Eigen::VectorXd mod_left;
+    Eigen::VectorXd mod_right;
+
+    auto start = chrono::high_resolution_clock::now();
+    tie(hits_left, hits_right, hits_left_inds, hits_right_inds, mod_left, mod_right) = embree_compute_hits(pings[i].pos_ - offset, R, 1.4*pings[i].port.tilt_angle, pings[i].port.beam_width + 0.2, V1, F1);
+    auto stop = chrono::high_resolution_clock::now();
+    auto duration = chrono::duration_cast<chrono::microseconds>(stop - start);
+    cout << "embree_compute_hits time: " << duration.count() << " microseconds" << endl;
+
+    Eigen::MatrixXd normals_left(hits_left.rows(), 3);
+    Eigen::MatrixXd normals_right(hits_right.rows(), 3);
+
+    for (int j = 0; j < hits_left.rows(); ++j) {
+        normals_left.row(j) = N_faces.row(hits_left_inds(j));
+    }
+
+    for (int j = 0; j < hits_right.rows(); ++j) {
+        normals_right.row(j) = N_faces.row(hits_right_inds(j));
+    }
+
+    return make_tuple(hits_left, hits_right, normals_left, normals_right);
+}
+
+Eigen::VectorXd BaseDraper::compute_times(const Eigen::MatrixXd& P)
+{
+    Eigen::Vector3d pos = pings[i].pos_ - offset;
+    double sound_vel = sound_speeds[0].vels.head(sound_speeds[0].vels.rows()-1).mean();
+    Eigen::VectorXd times = 2.*(P.rowwise() - pos.transpose()).rowwise().norm()/sound_vel;
+    return times;
+}
+
+Eigen::VectorXd BaseDraper::convert_to_time_bins(const Eigen::VectorXd& times, const Eigen::VectorXd& values,
+                                                 const xtf_data::xtf_sss_ping_side& ping, size_t nbr_windows)
+{
+    double ping_step = ping.time_duration / double(nbr_windows);
+    Eigen::VectorXd value_windows = Eigen::VectorXd::Zero(nbr_windows);
+    Eigen::ArrayXd value_counts = Eigen::ArrayXd::Zero(nbr_windows);
+    for (int i = 0; i < times.rows(); ++i) {
+        int index = int(times(i)/ping_step);
+        if (index < nbr_windows) {
+            value_windows(index) += values(i);
+            value_counts(index) += 1.;
+        }
+    }
+    value_counts += (value_counts == 0).cast<double>();
+    value_windows.array() /= value_counts;
+
+    return value_windows;
+}
+
+Eigen::VectorXd BaseDraper::compute_intensities(const Eigen::VectorXd& times, 
+                                                const xtf_data::xtf_sss_ping_side& ping)
+{
+    double ping_step = ping.time_duration / double(ping.pings.size());
+
+    Eigen::VectorXd intensities = Eigen::VectorXd::Zero(times.size());
+    for (int i = 0; i < times.rows(); ++i) {
+        int ping_index = int(times(i)/ping_step);
+        if (ping_index < ping.pings.size()) {
+            intensities(i) += double(ping.pings[ping_index])/10000.;
+        }
+    }
+    return intensities;
+}
+
+void BaseDraper::visualize_rays(const Eigen::MatrixXd& hits_left, const Eigen::MatrixXd& hits_right)
+{
+    Eigen::MatrixXi E;
+    Eigen::MatrixXd P(hits_left.rows(), 3);
+    P.rowwise() = (pings[i].pos_ - offset).transpose();
+    viewer.data().set_edges(P, E, Eigen::RowVector3d(1., 0., 0.));
+    viewer.data().add_edges(P, hits_left, Eigen::RowVector3d(1., 0., 0.));
+    P = Eigen::MatrixXd(hits_right.rows(), 3);
+    P.rowwise() = (pings[i].pos_ - offset).transpose();
+    viewer.data().add_edges(P, hits_right, Eigen::RowVector3d(0., 1., 0.));
+}
+
+void BaseDraper::visualize_vehicle()
+{
+    if (V2.rows() == 0) {
+        return;
+    }
+    Eigen::Matrix3d Rcomp = Eigen::AngleAxisd(sensor_yaw, Eigen::Vector3d::UnitZ()).matrix();
+    Eigen::Matrix3d Ry = Eigen::AngleAxisd(pings[i].pitch_, Eigen::Vector3d::UnitY()).matrix();
+    Eigen::Matrix3d Rz = Eigen::AngleAxisd(pings[i].heading_, Eigen::Vector3d::UnitZ()).matrix();
+    Eigen::Matrix3d R = Rz*Ry*Rcomp;
+
+    V.bottomRows(V2.rows()) = V2;
+    V.bottomRows(V2.rows()) *= R.transpose();
+    V.bottomRows(V2.rows()).array().rowwise() += (pings[i].pos_ - offset).transpose().array();
+    viewer.data().set_vertices(V);
+}
+
+Eigen::VectorXd BaseDraper::compute_model_intensities(const Eigen::MatrixXd& hits, const Eigen::MatrixXd& normals,
+                                                      const Eigen::Vector3d& origin)
+{
+    Eigen::VectorXd intensities(hits.rows());
+
+    for (int j = 0; j < hits.rows(); ++j) { 
+        Eigen::Vector3d dir = origin - hits.row(j).transpose();
+        double dist = dir.norm();
+        dir.normalize();
+        Eigen::Vector3d n = normals.row(j).transpose();
+        n.normalize();
+        intensities(j) = std::min(fabs(dir.dot(n))*(20./dist), 1.);
+    }
+
+    return intensities;
+}

--- a/src/bathy_maps/src/drape_mesh.cpp
+++ b/src/bathy_maps/src/drape_mesh.cpp
@@ -89,7 +89,8 @@ tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXi, Eigen::MatrixXi, Eigen:
     igl::Hit hit;
     Eigen::MatrixXd dirs_left;
     Eigen::MatrixXd dirs_right;
-    tie(dirs_left, dirs_right) = compute_sss_dirs(R, tilt_angle, beam_width, 220);
+    //tie(dirs_left, dirs_right) = compute_sss_dirs(R, tilt_angle, beam_width, 220);
+    tie(dirs_left, dirs_right) = compute_sss_dirs(R, tilt_angle, beam_width, 300);
     auto stop = chrono::high_resolution_clock::now();
     auto duration = chrono::duration_cast<chrono::microseconds>(stop - start);
     cout << "compute_sss_dirs time: " << duration.count() << " microseconds" << endl;

--- a/src/bathy_maps/src/map_draper.cpp
+++ b/src/bathy_maps/src/map_draper.cpp
@@ -44,6 +44,61 @@ bool MapDraper::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
         return false;
     }
 
+    Eigen::Vector3d pos = pings[i].pos_ - offset;
+
+    Eigen::MatrixXd hits_left;
+    Eigen::MatrixXd hits_right;
+    Eigen::MatrixXd normals_left;
+    Eigen::MatrixXd normals_right;
+    tie(hits_left, hits_right, normals_left, normals_right) = project();
+
+    // these should take care of computing bending if set
+    Eigen::VectorXd times_left = compute_times(hits_left);
+    Eigen::VectorXd times_right = compute_times(hits_right);
+
+    // compute the elevation waterfall row
+    Eigen::VectorXd sss_depths_left = convert_to_time_bins(times_left, hits_left.col(2), pings[i].port, map_image_builder.get_waterfall_bins());
+    Eigen::VectorXd sss_depths_right = convert_to_time_bins(times_right, hits_right.col(2), pings[i].stbd, map_image_builder.get_waterfall_bins());
+
+    // compute the intensities of the model
+    Eigen::VectorXd model_intensities_left = compute_model_intensities(hits_left, normals_left, pos);
+    Eigen::VectorXd model_intensities_right = compute_model_intensities(hits_right, normals_right, pos);
+    Eigen::VectorXd sss_model_left = convert_to_time_bins(times_left, model_intensities_left, pings[i].port, map_image_builder.get_waterfall_bins());
+    Eigen::VectorXd sss_model_right = convert_to_time_bins(times_right, model_intensities_right, pings[i].stbd, map_image_builder.get_waterfall_bins());
+
+    // compute the ground truth intensities
+    Eigen::VectorXd intensities_left = compute_intensities(times_left, pings[i].port);
+    Eigen::VectorXd intensities_right = compute_intensities(times_right, pings[i].stbd);
+
+    // add the 3d hits and waterfall images to the builder object
+    map_image_builder.add_hits(hits_left, intensities_left, sss_depths_left, sss_model_left, pings[i].port, pos, true);
+    map_image_builder.add_hits(hits_right, intensities_right, sss_depths_right, sss_model_right, pings[i].stbd, pos, false);
+
+    if (i % 10 == 0) {
+        visualize_rays(hits_left, hits_right);
+        visualize_vehicle();
+    }
+
+    ++i;
+
+    return false;
+}
+
+/*
+bool MapDraper::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
+{
+    // check if ping is first_in_file_, in that case, split off new image
+    if ((i == pings.size() - 1 || (i+1 < pings.size() && pings[i+1].first_in_file_)) && !map_image_builder.empty()) {
+        sss_map_image map_image = map_image_builder.finish();
+        save_callback(map_image);
+        map_images.push_back(map_image);
+        map_image_builder = sss_map_image_builder(bounds, resolution, pings[i].port.pings.size());
+    }
+
+    if (i >= pings.size()) {
+        return false;
+    }
+
     Eigen::MatrixXd hits_left_intensities, hits_right_intensities;
     Eigen::VectorXi hits_left_pings_indices, hits_right_pings_indices;
     Eigen::Vector3d pos;
@@ -56,6 +111,7 @@ bool MapDraper::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
 
     return false;
 }
+*/
 
 void MapDraper::set_resolution(double new_resolution)
 { 

--- a/src/bathy_maps/src/sss_gen_sim.cpp
+++ b/src/bathy_maps/src/sss_gen_sim.cpp
@@ -33,7 +33,7 @@ SSSGenSim::SSSGenSim(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
       sss_from_waterfall(false)
 {
     resample_window_height = 32;
-    full_window_height = 32;
+    full_window_height = 64;
 
     viewer.callback_pre_draw = std::bind(&SSSGenSim::callback_pre_draw, this, std::placeholders::_1);
     window_point = Eigen::Vector3d::Zero();
@@ -52,6 +52,7 @@ SSSGenSim::SSSGenSim(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
     texture = Eigen::MatrixXd::Zero(20, 9*20);
 
     waterfall_depth = Eigen::MatrixXd::Zero(full_window_height, 2*nbr_windows);
+    waterfall_model = Eigen::MatrixXd::Zero(full_window_height, 2*nbr_windows);
     waterfall_row = 0;
 }
 
@@ -168,41 +169,6 @@ void SSSGenSim::generate_sss_window()
 
 }
 
-tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> SSSGenSim::project()
-{
-    cout << "Setting new position: " << pings[i].pos_.transpose() << endl;
-    Eigen::Matrix3d Rcomp = Eigen::AngleAxisd(sensor_yaw, Eigen::Vector3d::UnitZ()).matrix();
-    Eigen::Matrix3d Ry = Eigen::AngleAxisd(pings[i].pitch_, Eigen::Vector3d::UnitY()).matrix();
-    Eigen::Matrix3d Rz = Eigen::AngleAxisd(pings[i].heading_, Eigen::Vector3d::UnitZ()).matrix();
-    Eigen::Matrix3d R = Rz*Ry*Rcomp;
-
-    Eigen::MatrixXd hits_left;
-    Eigen::MatrixXd hits_right;
-    Eigen::VectorXi hits_left_inds;
-    Eigen::VectorXi hits_right_inds;
-    Eigen::VectorXd mod_left;
-    Eigen::VectorXd mod_right;
-
-    auto start = chrono::high_resolution_clock::now();
-    tie(hits_left, hits_right, hits_left_inds, hits_right_inds, mod_left, mod_right) = embree_compute_hits(pings[i].pos_ - offset, R, 1.4*pings[i].port.tilt_angle, pings[i].port.beam_width + 0.2, V1, F1);
-    auto stop = chrono::high_resolution_clock::now();
-    auto duration = chrono::duration_cast<chrono::microseconds>(stop - start);
-    cout << "embree_compute_hits time: " << duration.count() << " microseconds" << endl;
-
-    Eigen::MatrixXd normals_left(hits_left.rows(), 3);
-    Eigen::MatrixXd normals_right(hits_right.rows(), 3);
-
-    for (int j = 0; j < hits_left.rows(); ++j) {
-        normals_left.row(j) = N_faces.row(hits_left_inds(j));
-    }
-
-    for (int j = 0; j < hits_right.rows(); ++j) {
-        normals_right.row(j) = N_faces.row(hits_right_inds(j));
-    }
-
-    return make_tuple(hits_left, hits_right, normals_left, normals_right);
-}
-
 Eigen::MatrixXd SSSGenSim::get_UV(const Eigen::MatrixXd& P)
 {
     double resolution = double(height_map_cv.cols)/(bounds(1, 0) - bounds(0, 0));
@@ -236,114 +202,14 @@ Eigen::VectorXd SSSGenSim::get_texture_intensities(const Eigen::MatrixXd& P)
     return intensities;
 }
 
-Eigen::VectorXd SSSGenSim::compute_model_intensities(const Eigen::MatrixXd& hits, const Eigen::MatrixXd& normals,
-                                                     const Eigen::Vector3d& origin)
-{
-    Eigen::VectorXd intensities(hits.rows());
-
-    for (int j = 0; j < hits.rows(); ++j) { 
-        Eigen::Vector3d dir = origin - hits.row(j).transpose();
-        double dist = dir.norm();
-        dir.normalize();
-        Eigen::Vector3d n = normals.row(j).transpose();
-        n.normalize();
-        intensities(j) = std::min(fabs(dir.dot(n))*(20./dist), 1.);
-    }
-
-    return intensities;
-}
-
-Eigen::VectorXd SSSGenSim::compute_times(const Eigen::MatrixXd& P)
-{
-    Eigen::Vector3d pos = pings[i].pos_ - offset;
-    double sound_vel = sound_speeds[0].vels.head(sound_speeds[0].vels.rows()-1).mean();
-    Eigen::VectorXd times = 2.*(P.rowwise() - pos.transpose()).rowwise().norm()/sound_vel;
-    return times;
-}
-
-Eigen::VectorXd SSSGenSim::compute_time_windows(const Eigen::VectorXd& times, const Eigen::VectorXd& intensities, const xtf_data::xtf_sss_ping_side& ping)
-{
-    double ping_step = ping.time_duration / double(nbr_windows);
-    Eigen::VectorXd time_windows = Eigen::VectorXd::Zero(nbr_windows);
-    Eigen::VectorXd time_counts = Eigen::VectorXd::Zero(nbr_windows);
-    for (int i = 0; i < times.rows(); ++i) {
-        int index = int(times(i)/ping_step);
-        if (index < nbr_windows) {
-            time_windows(index) += intensities(i);
-            time_counts(index) += 1.;
-        }
-    }
-    time_windows.array() /= time_counts.array();
-    return time_windows;
-}
-
-Eigen::VectorXd SSSGenSim::compute_depth_windows(const Eigen::VectorXd& times, const Eigen::MatrixXd& hits, const xtf_data::xtf_sss_ping_side& ping)
-{
-    double ping_step = ping.time_duration / double(nbr_windows);
-    Eigen::VectorXd depth_windows = Eigen::VectorXd::Zero(nbr_windows);
-    Eigen::VectorXd depth_counts = Eigen::VectorXd::Zero(nbr_windows);
-    for (int i = 0; i < times.rows(); ++i) {
-        int index = int(times(i)/ping_step);
-        if (index < nbr_windows) {
-            depth_windows(index) += hits(i, 2);
-            depth_counts(index) += 1.;
-        }
-    }
-    depth_windows.array() /= depth_counts.array();
-    return depth_windows;
-}
-
-/*
-Eigen::VectorXd SSSGenSim::match_intensities(const Eigen::VectorXd& times, const xtf_data::xtf_sss_ping_side& ping)
-{
-    double ping_step = ping.time_duration / double(nbr_windows);
-    Eigen::VectorXd time_windows = Eigen::VectorXd::Zero(nbr_windows);
-    Eigen::VectorXd time_counts = Eigen::VectorXd::Zero(nbr_windows);
-    for (int i = 0; i < times.rows(); ++i) {
-        int index = int(times(i)/ping_step);
-        if (index < nbr_windows) {
-            time_windows(index) += intensities(i);
-            time_counts(index) += 1.;
-        }
-    }
-    time_windows.array() /= time_counts.array();
-    return time_windows;
-}
-*/
-
-void SSSGenSim::visualize_rays(const Eigen::MatrixXd& hits_left, const Eigen::MatrixXd& hits_right)
-{
-    Eigen::MatrixXi E;
-    Eigen::MatrixXd P(hits_left.rows(), 3);
-    P.rowwise() = (pings[i].pos_ - offset).transpose();
-    viewer.data().set_edges(P, E, Eigen::RowVector3d(1., 0., 0.));
-    viewer.data().add_edges(P, hits_left, Eigen::RowVector3d(1., 0., 0.));
-    P = Eigen::MatrixXd(hits_right.rows(), 3);
-    P.rowwise() = (pings[i].pos_ - offset).transpose();
-    viewer.data().add_edges(P, hits_right, Eigen::RowVector3d(0., 1., 0.));
-}
-
-void SSSGenSim::visualize_vehicle()
-{
-    if (V2.rows() == 0) {
-        return;
-    }
-    Eigen::Matrix3d Rcomp = Eigen::AngleAxisd(sensor_yaw, Eigen::Vector3d::UnitZ()).matrix();
-    Eigen::Matrix3d Ry = Eigen::AngleAxisd(pings[i].pitch_, Eigen::Vector3d::UnitY()).matrix();
-    Eigen::Matrix3d Rz = Eigen::AngleAxisd(pings[i].heading_, Eigen::Vector3d::UnitZ()).matrix();
-    Eigen::Matrix3d R = Rz*Ry*Rcomp;
-
-    V.bottomRows(V2.rows()) = V2;
-    V.bottomRows(V2.rows()) *= R.transpose();
-    V.bottomRows(V2.rows()).array().rowwise() += (pings[i].pos_ - offset).transpose().array();
-    viewer.data().set_vertices(V);
-}
-
 void SSSGenSim::construct_gt_waterfall()
 {
     cv::Mat shifted = cv::Mat::zeros(waterfall_image.rows, waterfall_image.cols, waterfall_image.type());
     gt_waterfall_image(cv::Rect(0, 0, waterfall_image.cols, waterfall_image.rows-1)).copyTo(shifted(cv::Rect(0, 1, shifted.cols, shifted.rows-1)));
     shifted.copyTo(gt_waterfall_image);
+
+    Eigen::ArrayXd values = Eigen::ArrayXd::Zero(2*nbr_windows);
+    Eigen::ArrayXd value_counts = Eigen::ArrayXd::Zero(2*nbr_windows);
 
     double ping_step = double(pings[i].port.pings.size())/double(nbr_windows);
     for (int j = 0; j < pings[i].port.pings.size(); ++j) {
@@ -354,12 +220,22 @@ void SSSGenSim::construct_gt_waterfall()
         int right_index = nbr_windows+int(double(j)/ping_step);
 
         if (left_index > 0) {
-            gt_waterfall_image.at<uint8_t>(0, left_index) = uint8_t(255.*left_intensity);
+            values(left_index) += left_intensity;
+            value_counts(left_index) += 1.;
+            //gt_waterfall_image.at<uint8_t>(0, left_index) = uint8_t(255.*left_intensity);
         }
         if (right_index < 2*nbr_windows) {
-            gt_waterfall_image.at<uint8_t>(0, right_index) = uint8_t(255.*right_intensity);
+            values(right_index) += right_intensity;
+            value_counts(right_index) += 1.;
+            //gt_waterfall_image.at<uint8_t>(0, right_index) = uint8_t(255.*right_intensity);
         }
 
+    }
+    value_counts += (value_counts == 0).cast<double>();
+    values /= value_counts;
+
+    for (int j = 0; j < 2*nbr_windows; ++j) {
+        gt_waterfall_image.at<uint8_t>(0, j) = uint8_t(255.*values(j));
     }
 }
 
@@ -400,7 +276,8 @@ bool SSSGenSim::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
 
     if (sss_from_waterfall) {
         if (waterfall_row == resample_window_height) {
-            Eigen::MatrixXd generated = gen_callback(waterfall_depth);
+            //Eigen::MatrixXd generated = gen_callback(waterfall_depth);
+            Eigen::MatrixXd generated = gen_callback(waterfall_model);
             for (int row = 0; row < resample_window_height; ++row) {
                 for (int col = 0; col < generated.cols(); ++col) {
                     waterfall_image.at<uint8_t>(row, col) = uint8_t(255.*generated(row, col));
@@ -410,6 +287,9 @@ bool SSSGenSim::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
                 Eigen::MatrixXd temp = waterfall_depth.topRows(full_window_height-resample_window_height);
                 waterfall_depth.bottomRows(full_window_height-resample_window_height) = temp;
                 waterfall_depth.topRows(resample_window_height).setZero();
+                temp = waterfall_model.topRows(full_window_height-resample_window_height);
+                waterfall_model.bottomRows(full_window_height-resample_window_height) = temp;
+                waterfall_model.topRows(resample_window_height).setZero();
             }
             waterfall_row = 0;
         }
@@ -422,23 +302,38 @@ bool SSSGenSim::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
         }
     }
 
+    // compute 3d hits and normals
     Eigen::MatrixXd hits_left;
     Eigen::MatrixXd hits_right;
     Eigen::MatrixXd normals_left;
     Eigen::MatrixXd normals_right;
     tie(hits_left, hits_right, normals_left, normals_right) = project();
 
+    // compute travel times
     Eigen::VectorXd times_left = compute_times(hits_left);
     Eigen::VectorXd times_right = compute_times(hits_right);
 
+    // shift the waterfall image
     cv::Mat shifted = cv::Mat::zeros(waterfall_image.rows, waterfall_image.cols, waterfall_image.type());
     waterfall_image(cv::Rect(0, 0, waterfall_image.cols, waterfall_image.rows-1)).copyTo(shifted(cv::Rect(0, 1, shifted.cols, shifted.rows-1)));
     shifted.copyTo(waterfall_image);
 
     if (sss_from_waterfall) {
+    
+        Eigen::Vector3d pos = pings[i].pos_ - offset;
 
-        Eigen::VectorXd depth_windows_left = compute_depth_windows(times_left, hits_left, pings[i].port);
-        Eigen::VectorXd depth_windows_right = compute_depth_windows(times_right, hits_right, pings[i].stbd);
+        // maybe do this outside the statement and reuse them for the cv image generation
+        Eigen::VectorXd model_windows_left = convert_to_time_bins(times_left, compute_model_intensities(hits_left, normals_left, pos), pings[i].port, nbr_windows);
+        Eigen::VectorXd model_windows_right = convert_to_time_bins(times_right, compute_model_intensities(hits_right, normals_right, pos), pings[i].stbd, nbr_windows);
+
+        Eigen::VectorXd model_windows(model_windows_left.rows() + model_windows_right.rows());
+        model_windows.tail(model_windows_right.rows()) = model_windows_right;
+        model_windows.head(model_windows_left.rows()) = model_windows_left.reverse();
+
+        waterfall_model.row(resample_window_height-waterfall_row-1) = model_windows.transpose();
+
+        Eigen::VectorXd depth_windows_left = convert_to_time_bins(times_left, hits_left.col(2), pings[i].port, nbr_windows);
+        Eigen::VectorXd depth_windows_right = convert_to_time_bins(times_right, hits_right.col(2), pings[i].stbd, nbr_windows);
 
         Eigen::VectorXd depth_windows(depth_windows_left.rows() + depth_windows_right.rows());
         depth_windows.tail(depth_windows_right.rows()) = depth_windows_right;
@@ -453,8 +348,8 @@ bool SSSGenSim::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
         Eigen::VectorXd intensities_left = get_texture_intensities(hits_left);
         Eigen::VectorXd intensities_right = get_texture_intensities(hits_right);
 
-        Eigen::VectorXd time_windows_left = compute_time_windows(times_left, intensities_left, pings[i].port);
-        Eigen::VectorXd time_windows_right = compute_time_windows(times_right, intensities_right, pings[i].stbd);
+        Eigen::VectorXd time_windows_left = convert_to_time_bins(times_left, intensities_left, pings[i].port, nbr_windows);
+        Eigen::VectorXd time_windows_right = convert_to_time_bins(times_right, intensities_right, pings[i].stbd, nbr_windows);
 
         Eigen::VectorXd time_windows(time_windows_left.rows() + time_windows_right.rows());
         time_windows.tail(time_windows_right.rows()) = time_windows_right;
@@ -466,7 +361,10 @@ bool SSSGenSim::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
 
     }
 
+    // construct the ground truth waterfall image for timestep
     construct_gt_waterfall();
+
+    // construct the model waterfall image for timestep
     construct_model_waterfall(hits_left, hits_right, normals_left, normals_right, times_left, times_right);
 
     cv::imshow("GAN waterfall image", waterfall_image);

--- a/src/bathy_maps/src/sss_gen_sim.cpp
+++ b/src/bathy_maps/src/sss_gen_sim.cpp
@@ -39,6 +39,7 @@ SSSGenSim::SSSGenSim(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
     right_row_mean = 0.;
 
     viewer.callback_pre_draw = std::bind(&SSSGenSim::callback_pre_draw, this, std::placeholders::_1);
+    viewer.callback_key_pressed = std::bind(&SSSGenSim::callback_key_pressed, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
     window_point = Eigen::Vector3d::Zero();
     window_heading = 0.;
     height_map_cv = cv::Mat(height_map.rows(), height_map.cols(), CV_32FC1);
@@ -57,6 +58,19 @@ SSSGenSim::SSSGenSim(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
     waterfall_depth = Eigen::MatrixXd::Zero(full_window_height, 2*nbr_windows);
     waterfall_model = Eigen::MatrixXd::Zero(full_window_height, 2*nbr_windows);
     waterfall_row = 0;
+}
+
+bool SSSGenSim::callback_key_pressed(igl::opengl::glfw::Viewer& viewer, unsigned int key, int mods)
+{
+    switch (key) {
+    case 'n':
+        while (i < pings.size() && !pings[i].first_in_file_) {
+            ++i;
+        }
+        return true;
+    default:
+        return false;
+    }
 }
 
 Eigen::MatrixXd scale_height_map(const Eigen::MatrixXd& height_map)

--- a/src/bathy_maps/src/sss_map_image.cpp
+++ b/src/bathy_maps/src/sss_map_image.cpp
@@ -31,6 +31,12 @@ sss_map_image_builder::sss_map_image_builder(const sss_map_image::BoundsT& bound
     sss_waterfall_image = Eigen::MatrixXd::Zero(2000, waterfall_width);
     sss_waterfall_cross_track = Eigen::MatrixXd::Zero(2000, waterfall_width);
     sss_waterfall_depth = Eigen::MatrixXd::Zero(2000, waterfall_width);
+    sss_waterfall_model = Eigen::MatrixXd::Zero(2000, waterfall_width);
+}
+
+size_t sss_map_image_builder::get_waterfall_bins()
+{
+    return waterfall_width / 2;
 }
 
 bool sss_map_image_builder::empty()
@@ -40,6 +46,10 @@ bool sss_map_image_builder::empty()
 
 Eigen::MatrixXd sss_map_image_builder::downsample_cols(const Eigen::MatrixXd& M, int new_cols)
 {
+    if (new_cols == M.cols()) {
+        return M;
+    }
+
     double factor = double(new_cols)/double(M.cols());
     Eigen::ArrayXXd sums = Eigen::MatrixXd::Zero(M.rows(), new_cols);
     Eigen::ArrayXXd counts = Eigen::MatrixXd::Zero(M.rows(), new_cols);
@@ -48,8 +58,10 @@ Eigen::MatrixXd sss_map_image_builder::downsample_cols(const Eigen::MatrixXd& M,
     for (int i = 0; i < M.rows(); ++i) {
         for (int j = 0; j < M.cols(); ++j) {
             ind = int(factor*j);
-            sums(i, ind) += M(i, j);
-            counts(i, ind) += 1.;
+            if (M(i, j) != 0) {
+                sums(i, ind) += M(i, j);
+                counts(i, ind) += 1.;
+            }
         }
     }
 
@@ -68,9 +80,10 @@ sss_map_image sss_map_image_builder::finish()
         map_image.sss_map_image.array() = sss_map_image_sums.array() / sss_map_image_counts.array();
     }
     map_image.pos = poss;
-    map_image.sss_waterfall_image = downsample_cols(sss_waterfall_image.topRows(waterfall_counter), 1000).cast<float>();
+    map_image.sss_waterfall_image = downsample_cols(sss_waterfall_image.topRows(waterfall_counter), 512).cast<float>();
     //map_image.sss_waterfall_cross_track = sss_waterfall_cross_track.topRows(waterfall_counter);
-    map_image.sss_waterfall_depth = downsample_cols(sss_waterfall_depth.topRows(waterfall_counter), 1000).cast<float>();
+    map_image.sss_waterfall_depth = downsample_cols(sss_waterfall_depth.topRows(waterfall_counter), 512).cast<float>();
+    map_image.sss_waterfall_model = downsample_cols(sss_waterfall_model.topRows(waterfall_counter), 512).cast<float>();
 
     return map_image;
 }
@@ -144,6 +157,68 @@ void sss_map_image_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::V
     std::cout << "Number inside image: " << inside_image << std::endl;
 
     add_waterfall_images(hits, hits_inds, ping, pos, is_left);
+}
+
+void sss_map_image_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXd& intensities,
+                                     const Eigen::VectorXd& sss_depths, const Eigen::VectorXd& sss_model,
+                                     const xtf_sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left)
+{
+    if (hits.rows() == 0) {
+        return;
+    }
+
+    poss.push_back(pos);
+
+    Eigen::MatrixXd points = hits;
+    // The hits are already compensated to start at bounds.row(0)
+    //points.array().rowwise() -= global_origin.array().transpose();
+    points.leftCols<2>().array() *= resolution; //*points.leftCols<2>().array();
+
+    std::cout << "Hits rows: " << hits.rows() << std::endl;
+    std::cout << "Origin: " << global_origin.transpose() << ", pose: " << pos.transpose() << std::endl;
+
+    int inside_image = 0;
+    for (int i = 0; i < points.rows(); ++i) {
+        int x = int(points(i, 0));
+        int y = int(points(i, 1));
+        if (x >= 0 && x < image_cols && y >= 0 && y < image_rows) {
+            sss_map_image_sums(y, x) += intensities(i);
+            sss_map_image_counts(y, x) += 1.;
+            ++inside_image;
+        }
+    }
+    std::cout << "Number inside image: " << inside_image << std::endl;
+
+    if (waterfall_counter > sss_waterfall_image.rows()) {
+        sss_waterfall_image.conservativeResize(sss_waterfall_image.rows()+1000, sss_waterfall_image.cols());
+        sss_waterfall_cross_track.conservativeResize(sss_waterfall_image.rows()+1000, sss_waterfall_image.cols());
+        sss_waterfall_depth.conservativeResize(sss_waterfall_image.rows()+1000, sss_waterfall_image.cols());
+        sss_waterfall_model.conservativeResize(sss_waterfall_image.rows()+1000, sss_waterfall_image.cols());
+    }
+
+    for (int i = 0; i < ping.pings.size(); ++i) {
+        int col;
+        if (is_left) {
+            col = waterfall_width/2 + i;
+        }
+        else {
+            col = waterfall_width/2 - 1 - i;
+        }
+        sss_waterfall_image(waterfall_counter, col) = double(ping.pings[i])/10000.;
+    }
+
+    if (is_left) {
+        sss_waterfall_depth.block(waterfall_counter, waterfall_width/2, 1, waterfall_width/2) = sss_depths.transpose();
+        sss_waterfall_model.block(waterfall_counter, waterfall_width/2, 1, waterfall_width/2) = sss_model.transpose();
+    }
+    else {
+        sss_waterfall_depth.block(waterfall_counter, 0, 1, waterfall_width/2) = sss_depths.reverse().transpose();
+        sss_waterfall_model.block(waterfall_counter, 0, 1, waterfall_width/2) = sss_model.reverse().transpose();
+    }
+
+    if (!is_left) {
+        ++waterfall_counter;
+    }
 }
 
 sss_patch_views::ViewsT convert_maps_to_patches(const sss_map_image::ImagesT& map_images, const Eigen::MatrixXd& height_map, double patch_size)

--- a/src/bathy_maps/src/sss_map_image.cpp
+++ b/src/bathy_maps/src/sss_map_image.cpp
@@ -34,6 +34,11 @@ sss_map_image_builder::sss_map_image_builder(const sss_map_image::BoundsT& bound
     sss_waterfall_model = Eigen::MatrixXd::Zero(2000, waterfall_width);
 }
 
+pair<int, int> sss_map_image_builder::get_map_image_shape()
+{
+    return make_pair(image_rows, image_cols);
+}
+
 size_t sss_map_image_builder::get_waterfall_bins()
 {
     return waterfall_width / 2;

--- a/src/bathy_maps/src/sss_map_image.cpp
+++ b/src/bathy_maps/src/sss_map_image.cpp
@@ -79,6 +79,7 @@ sss_map_image sss_map_image_builder::finish()
         sss_map_image_counts.array() += (sss_map_image_counts.array() == 0).cast<double>();
         map_image.sss_map_image.array() = sss_map_image_sums.array() / sss_map_image_counts.array();
     }
+    map_image.sss_ping_duration = sss_ping_duration;
     map_image.pos = poss;
     map_image.sss_waterfall_image = downsample_cols(sss_waterfall_image.topRows(waterfall_counter), 512).cast<float>();
     //map_image.sss_waterfall_cross_track = sss_waterfall_cross_track.topRows(waterfall_counter);
@@ -133,6 +134,7 @@ void sss_map_image_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::V
         return;
     }
 
+    sss_ping_duration = ping.time_duration;
     poss.push_back(pos);
 
     Eigen::VectorXd intensities = hits.col(3);
@@ -167,6 +169,7 @@ void sss_map_image_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::V
         return;
     }
 
+    sss_ping_duration = ping.time_duration;
     poss.push_back(pos);
 
     Eigen::MatrixXd points = hits;

--- a/src/pybathy_maps/src/pymap_draper.cpp
+++ b/src/pybathy_maps/src/pymap_draper.cpp
@@ -34,6 +34,7 @@ PYBIND11_MODULE(map_draper, m) {
         .def_readwrite("sss_waterfall_depth", &sss_map_image::sss_waterfall_depth, "Member")
         .def_readwrite("sss_waterfall_model", &sss_map_image::sss_waterfall_model, "Member")
         .def_readwrite("pos", &sss_map_image::pos, "Member")
+        .def_readwrite("sss_ping_duration", &sss_map_image::sss_ping_duration, "Member")
         .def_static("read_data", &read_data_from_str<sss_map_image::ImagesT>, "Read sss_map_image::ImagesT from .cereal file");
 
 

--- a/src/pybathy_maps/src/pymap_draper.cpp
+++ b/src/pybathy_maps/src/pymap_draper.cpp
@@ -32,6 +32,7 @@ PYBIND11_MODULE(map_draper, m) {
         .def_readwrite("sss_waterfall_image", &sss_map_image::sss_waterfall_image, "Member")
         .def_readwrite("sss_waterfall_cross_track", &sss_map_image::sss_waterfall_cross_track, "Member")
         .def_readwrite("sss_waterfall_depth", &sss_map_image::sss_waterfall_depth, "Member")
+        .def_readwrite("sss_waterfall_model", &sss_map_image::sss_waterfall_model, "Member")
         .def_readwrite("pos", &sss_map_image::pos, "Member")
         .def_static("read_data", &read_data_from_str<sss_map_image::ImagesT>, "Read sss_map_image::ImagesT from .cereal file");
 


### PR DESCRIPTION
This PR does a few things:

* Adds a couple of members in sss_map_image
* Overhauls the draper class methods with new stuff
* Changes the vis in map_draper

The actual user changes should be minor. The main change is that the old sss_map_image data format is binary incompatible with the new format. So you can't use the old "map_image_something.cereal" files.