### PR TITLE
Std sss ping

### DIFF
--- a/src/bathy_maps/include/bathy_maps/base_draper.h
+++ b/src/bathy_maps/include/bathy_maps/base_draper.h
@@ -85,12 +85,12 @@ protected:
 
     // NOTE: these are new style functions
     std::pair<Eigen::MatrixXd, Eigen::MatrixXd> compute_sss_dirs(const Eigen::Matrix3d& R, double tilt_angle, double beam_width, int nbr_lines);
-    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> project(const xtf_data::xtf_sss_ping& ping);
-    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd> trace_side(const xtf_data::xtf_sss_ping_side& ping,
+    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> project(const std_data::sss_ping& ping);
+    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd> trace_side(const std_data::sss_ping_side& ping,
                                                             const Eigen::Vector3d& sensor_origin,
                                                             const Eigen::MatrixXd& dirs);
 
-    ping_draping_result project_ping_side(const xtf_data::xtf_sss_ping_side& sensor, const Eigen::MatrixXd& hits,
+    ping_draping_result project_ping_side(const std_data::sss_ping_side& sensor, const Eigen::MatrixXd& hits,
                                           const Eigen::MatrixXd& hits_normals, const Eigen::Vector3d& origin,
                                           int nbr_bins);
 
@@ -99,16 +99,16 @@ protected:
     Eigen::VectorXd compute_refraction_times(const Eigen::Vector3d& sensor_origin, const Eigen::MatrixXd& P);
     Eigen::VectorXd compute_times(const Eigen::Vector3d& sensor_origin, const Eigen::MatrixXd& P);
 
-    std::pair<Eigen::Vector3d, Eigen::Vector3d> get_port_stbd_sensor_origins(const xtf_data::xtf_sss_ping& ping);
-    Eigen::VectorXi compute_bin_indices(const Eigen::VectorXd& times, const xtf_data::xtf_sss_ping_side& ping, size_t nbr_windows);
+    std::pair<Eigen::Vector3d, Eigen::Vector3d> get_port_stbd_sensor_origins(const std_data::sss_ping& ping);
+    Eigen::VectorXi compute_bin_indices(const Eigen::VectorXd& times, const std_data::sss_ping_side& ping, size_t nbr_windows);
 
     Eigen::VectorXd convert_to_time_bins(const Eigen::VectorXd& times, const Eigen::VectorXd& values,
-                                         const xtf_data::xtf_sss_ping_side& ping, size_t nbr_windows);
+                                         const std_data::sss_ping_side& ping, size_t nbr_windows);
     Eigen::MatrixXd convert_to_time_bins(const Eigen::VectorXd& times, const Eigen::MatrixXd& values,
-                                         const xtf_data::xtf_sss_ping_side& ping, size_t nbr_windows);
+                                         const std_data::sss_ping_side& ping, size_t nbr_windows);
 
     Eigen::VectorXd compute_intensities(const Eigen::VectorXd& times, 
-                                        const xtf_data::xtf_sss_ping_side& ping);
+                                        const std_data::sss_ping_side& ping);
 
     Eigen::VectorXd compute_lambert_intensities(const Eigen::MatrixXd& hits, const Eigen::MatrixXd& normals,
                                                 const Eigen::Vector3d& origin);
@@ -126,8 +126,8 @@ public:
                const BoundsT& bounds,
                const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds = csv_data::csv_asvp_sound_speed::EntriesT());
 
-    std::pair<ping_draping_result, ping_draping_result> project_ping(const xtf_data::xtf_sss_ping& ping, int nbr_bins);
-    Eigen::VectorXd compute_bin_intensities(const xtf_data::xtf_sss_ping_side& ping, int nbr_bins);
+    std::pair<ping_draping_result, ping_draping_result> project_ping(const std_data::sss_ping& ping, int nbr_bins);
+    Eigen::VectorXd compute_bin_intensities(const std_data::sss_ping_side& ping, int nbr_bins);
 
     void set_sidescan_yaw(double new_sensor_yaw) { sensor_yaw = new_sensor_yaw; }
     void set_sidescan_port_stbd_offsets(const Eigen::Vector3d& new_offset_port, const Eigen::Vector3d& new_offset_stbd) { sensor_offset_port = new_offset_port; sensor_offset_stbd = new_offset_stbd; }

--- a/src/bathy_maps/include/bathy_maps/impl/map_draper.hpp
+++ b/src/bathy_maps/include/bathy_maps/impl/map_draper.hpp
@@ -16,12 +16,11 @@
 //#include <bathy_maps/drape_mesh.h>
 
 using namespace std;
-using namespace xtf_data;
 using namespace csv_data;
 
 template <typename MapSaver>
 MapDraper<MapSaver>::MapDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
-                               const xtf_sss_ping::PingsT& pings,
+                               const std_data::sss_ping::PingsT& pings,
                                const BoundsT& bounds,
                                const csv_asvp_sound_speed::EntriesT& sound_speeds)
     : ViewDraper(V1, F1, pings, bounds, sound_speeds),

--- a/src/bathy_maps/include/bathy_maps/map_draper.h
+++ b/src/bathy_maps/include/bathy_maps/map_draper.h
@@ -43,7 +43,7 @@ public:
     void set_close_when_done(bool close) { close_when_done = close; }
 
     MapDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
-              const xtf_data::xtf_sss_ping::PingsT& pings,
+              const std_data::sss_ping::PingsT& pings,
               const BoundsT& bounds,
               const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds);
 
@@ -52,7 +52,7 @@ public:
 };
 
 sss_map_image::ImagesT drape_maps(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F,
-                                  const BaseDraper::BoundsT& bounds, const xtf_data::xtf_sss_ping::PingsT& pings,
+                                  const BaseDraper::BoundsT& bounds, const std_data::sss_ping::PingsT& pings,
                                   const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds, double sensor_yaw,
                                   double resolution, const std::function<void(sss_map_image)>& save_callback);
 

--- a/src/bathy_maps/include/bathy_maps/patch_draper.h
+++ b/src/bathy_maps/include/bathy_maps/patch_draper.h
@@ -34,12 +34,12 @@ public:
     void set_patch_callback(const std::function<void(sss_patch_views)>& callback) { save_callback = callback; }
 
     PatchDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
-                const xtf_data::xtf_sss_ping::PingsT& pings,
+                const std_data::sss_ping::PingsT& pings,
                 const BoundsT& bounds,
                 const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds);
 
     void handle_patches();
-    bool point_in_view(const xtf_data::xtf_sss_ping& ping, const Eigen::Vector3d& point, double sensor_yaw);
+    bool point_in_view(const std_data::sss_ping& ping, const Eigen::Vector3d& point, double sensor_yaw);
     bool callback_mouse_down(igl::opengl::glfw::Viewer& viewer, int, int);
     bool callback_key_pressed(igl::opengl::glfw::Viewer& viewer, unsigned int key, int mods);
     bool callback_pre_draw(igl::opengl::glfw::Viewer& viewer);
@@ -47,7 +47,7 @@ public:
 };
 
 sss_patch_views::ViewsT drape_patches(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F,
-                                      const PatchDraper::BoundsT& bounds, const xtf_data::xtf_sss_ping::PingsT& pings,
+                                      const PatchDraper::BoundsT& bounds, const std_data::sss_ping::PingsT& pings,
                                       const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds, double sensor_yaw,
                                       const std::function<void(sss_patch_views)>& save_callback = &PatchDraper::default_callback);
 

--- a/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
+++ b/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
@@ -112,8 +112,6 @@ protected:
 
     void generate_sss_window();
     //Eigen::VectorXd compute_times(const Eigen::MatrixXd& P);
-    //Eigen::VectorXd compute_time_windows(const Eigen::VectorXd& times, const Eigen::VectorXd& intensities, const xtf_data::xtf_sss_ping_side& ping);
-    //Eigen::VectorXd compute_depth_windows(const Eigen::VectorXd& times, const Eigen::MatrixXd& hits, const xtf_data::xtf_sss_ping_side& ping);
     //Eigen::VectorXd compute_model_intensities(const Eigen::MatrixXd& hits, const Eigen::MatrixXd& normals,
     //                                          const Eigen::Vector3d& origin);
     //void visualize_rays(const Eigen::MatrixXd& hits_left, const Eigen::MatrixXd& hits_right);
@@ -154,12 +152,5 @@ public:
     bool callback_key_pressed(igl::opengl::glfw::Viewer& viewer, unsigned int key, int mods);
     bool callback_pre_draw(igl::opengl::glfw::Viewer& viewer);
 };
-
-/*
-sss_map_image::ImagesT drape_maps(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F,
-                                  const SSSGenSim::BoundsT& bounds, const xtf_data::xtf_sss_ping::PingsT& pings,
-                                  const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds, double sensor_yaw,
-                                  double resolution, const std::function<Eigen::MatrixXd(const Eigen::MatrixXd&)>& gen_callback);
-*/
 
 #endif // SSS_GEN_SIM_H

--- a/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
+++ b/src/bathy_maps/include/bathy_maps/sss_gen_sim.h
@@ -146,7 +146,7 @@ public:
     //void set_resolution(double new_resolution);
 
     SSSGenSim(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
-              const xtf_data::xtf_sss_ping::PingsT& pings,
+              const std_data::sss_ping::PingsT& pings,
               const BoundsT& bounds,
               const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds,
               const Eigen::MatrixXd& height_map);

--- a/src/bathy_maps/include/bathy_maps/sss_map_image.h
+++ b/src/bathy_maps/include/bathy_maps/sss_map_image.h
@@ -18,7 +18,7 @@
 #include <cereal/types/vector.hpp>
 
 #include <bathy_maps/patch_views.h>
-#include <data_tools/xtf_data.h>
+#include <data_tools/std_data.h>
 
 struct sss_map_image {
 
@@ -91,15 +91,15 @@ public:
     sss_map_image finish();
 
     void add_waterfall_images(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
-                              const xtf_data::xtf_sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left);
+                              const std_data::sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left);
 
     void add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
-                  const xtf_data::xtf_sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left);
+                  const std_data::sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left);
 
     void add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
                   const Eigen::VectorXd& intensities,
                   const Eigen::VectorXd& sss_depths, const Eigen::VectorXd& sss_model,
-                  const xtf_data::xtf_sss_ping_side& ping, const Eigen::Vector3d& pos,
+                  const std_data::sss_ping_side& ping, const Eigen::Vector3d& pos,
                   const Eigen::Vector3d& rpy, bool is_left);
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/bathy_maps/include/bathy_maps/sss_meas_data.h
+++ b/src/bathy_maps/include/bathy_maps/sss_meas_data.h
@@ -16,8 +16,7 @@
 #include <eigen_cereal/eigen_cereal.h>
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/vector.hpp>
-
-#include <data_tools/xtf_data.h>
+#include <data_tools/std_data.h>
 
 struct sss_meas_data {
 
@@ -80,7 +79,7 @@ public:
     void add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
                   const Eigen::VectorXd& intensities,
                   const Eigen::VectorXd& sss_depths, const Eigen::VectorXd& sss_model,
-                  const xtf_data::xtf_sss_ping_side& ping, const Eigen::Vector3d& pos,
+                  const std_data::sss_ping_side& ping, const Eigen::Vector3d& pos,
                   const Eigen::Vector3d& rpy, bool is_left); // used
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/bathy_maps/include/bathy_maps/view_draper.h
+++ b/src/bathy_maps/include/bathy_maps/view_draper.h
@@ -13,7 +13,7 @@ public:
 protected:
 
     igl::opengl::glfw::Viewer viewer; // ligigl viewer object
-    xtf_data::xtf_sss_ping::PingsT pings; // sidescan pings used for draping
+    std_data::sss_ping::PingsT pings; // sidescan pings used for draping
     int i; // timestep counter, one step per ping
     int nbr_time_bins;
     
@@ -46,7 +46,7 @@ public:
     void set_vehicle_mesh(const Eigen::MatrixXd& new_V2, const Eigen::MatrixXi& new_F2, const Eigen::MatrixXd& new_C2);
 
     ViewDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
-               const xtf_data::xtf_sss_ping::PingsT& pings,
+               const std_data::sss_ping::PingsT& pings,
                const BoundsT& bounds,
                const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds = csv_data::csv_asvp_sound_speed::EntriesT());
 
@@ -57,7 +57,7 @@ public:
 std::tuple<Eigen::MatrixXd, Eigen::MatrixXi, Eigen::MatrixXd> get_vehicle_mesh();
 Eigen::MatrixXd color_jet_from_mesh(const Eigen::MatrixXd& V);
 void drape_viewer(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F,
-                  const ViewDraper::BoundsT& bounds, const xtf_data::xtf_sss_ping::PingsT& pings,
+                  const ViewDraper::BoundsT& bounds, const std_data::sss_ping::PingsT& pings,
                   const csv_data::csv_asvp_sound_speed::EntriesT& sound_speeds, double sensor_yaw);
 
 #endif // VIEW_DRAPER_H

--- a/src/bathy_maps/src/base_draper.cpp
+++ b/src/bathy_maps/src/base_draper.cpp
@@ -39,7 +39,7 @@ void BaseDraper::set_ray_tracing_enabled(bool enabled)
     ray_tracing_enabled = enabled;
 }
 
-pair<Eigen::Vector3d, Eigen::Vector3d> BaseDraper::get_port_stbd_sensor_origins(const xtf_data::xtf_sss_ping& ping)
+pair<Eigen::Vector3d, Eigen::Vector3d> BaseDraper::get_port_stbd_sensor_origins(const std_data::sss_ping& ping)
 {
     Eigen::Matrix3d Ry = Eigen::AngleAxisd(ping.pitch_, Eigen::Vector3d::UnitY()).matrix();
     Eigen::Matrix3d Rz = Eigen::AngleAxisd(ping.heading_, Eigen::Vector3d::UnitZ()).matrix();
@@ -72,7 +72,7 @@ pair<Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::compute_sss_dirs(const Eigen:
     return make_pair(dirs_left, dirs_right);
 }
 
-tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::project(const xtf_data::xtf_sss_ping& ping)
+tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::project(const std_data::sss_ping& ping)
 {
     cout << "Setting new position: " << ping.pos_.transpose() << endl;
     Eigen::Matrix3d Rcomp = Eigen::AngleAxisd(sensor_yaw, Eigen::Vector3d::UnitZ()).matrix();
@@ -116,7 +116,7 @@ tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> BaseDr
 }
 
 // New style functions follow here:
-tuple<Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::trace_side(const xtf_data::xtf_sss_ping_side& ping,
+tuple<Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::trace_side(const std_data::sss_ping_side& ping,
                                                                const Eigen::Vector3d& sensor_origin,
                                                                const Eigen::MatrixXd& dirs)
 {
@@ -210,7 +210,7 @@ Eigen::VectorXd BaseDraper::compute_refraction_times(const Eigen::Vector3d& sens
     return times;
 }
 
-Eigen::VectorXi BaseDraper::compute_bin_indices(const Eigen::VectorXd& times, const xtf_data::xtf_sss_ping_side& ping, size_t nbr_windows)
+Eigen::VectorXi BaseDraper::compute_bin_indices(const Eigen::VectorXd& times, const std_data::sss_ping_side& ping, size_t nbr_windows)
 {
     Eigen::VectorXi bin_inds = Eigen::VectorXi::Zero(times.rows());
 
@@ -229,7 +229,7 @@ Eigen::VectorXi BaseDraper::compute_bin_indices(const Eigen::VectorXd& times, co
 }
 
 Eigen::VectorXd BaseDraper::convert_to_time_bins(const Eigen::VectorXd& times, const Eigen::VectorXd& values,
-                                                 const xtf_data::xtf_sss_ping_side& ping, size_t nbr_windows)
+                                                 const std_data::sss_ping_side& ping, size_t nbr_windows)
 {
     double ping_step = ping.time_duration / double(nbr_windows);
     Eigen::VectorXd value_windows = Eigen::VectorXd::Zero(nbr_windows);
@@ -248,7 +248,7 @@ Eigen::VectorXd BaseDraper::convert_to_time_bins(const Eigen::VectorXd& times, c
 }
 
 Eigen::MatrixXd BaseDraper::convert_to_time_bins(const Eigen::VectorXd& times, const Eigen::MatrixXd& values,
-                                                 const xtf_data::xtf_sss_ping_side& ping, size_t nbr_windows)
+                                                 const std_data::sss_ping_side& ping, size_t nbr_windows)
 {
     double ping_step = ping.time_duration / double(nbr_windows);
     Eigen::MatrixXd value_windows = Eigen::MatrixXd::Zero(nbr_windows, values.cols());
@@ -267,7 +267,7 @@ Eigen::MatrixXd BaseDraper::convert_to_time_bins(const Eigen::VectorXd& times, c
 }
 
 Eigen::VectorXd BaseDraper::compute_intensities(const Eigen::VectorXd& times, 
-                                                const xtf_data::xtf_sss_ping_side& ping)
+                                                const std_data::sss_ping_side& ping)
 {
     double ping_step = ping.time_duration / double(ping.pings.size());
 
@@ -281,7 +281,7 @@ Eigen::VectorXd BaseDraper::compute_intensities(const Eigen::VectorXd& times,
     return intensities;
 }
 
-Eigen::VectorXd BaseDraper::compute_bin_intensities(const xtf_data::xtf_sss_ping_side& ping, int nbr_bins)
+Eigen::VectorXd BaseDraper::compute_bin_intensities(const std_data::sss_ping_side& ping, int nbr_bins)
 {
     auto start = chrono::high_resolution_clock::now();
     double ping_step = double(ping.pings.size()) / double(nbr_bins);
@@ -370,7 +370,7 @@ Eigen::VectorXd BaseDraper::compute_model_intensities(const Eigen::MatrixXd& hit
     return compute_model_intensities(dists, thetas);
 }
 
-pair<ping_draping_result, ping_draping_result> BaseDraper::project_ping(const xtf_data::xtf_sss_ping& ping, int nbr_bins)
+pair<ping_draping_result, ping_draping_result> BaseDraper::project_ping(const std_data::sss_ping& ping, int nbr_bins)
 {
     Eigen::MatrixXd hits_left;
     Eigen::MatrixXd hits_right;
@@ -406,7 +406,7 @@ pair<ping_draping_result, ping_draping_result> BaseDraper::project_ping(const xt
     return make_pair(left, right);
 }
 
-ping_draping_result BaseDraper::project_ping_side(const xtf_data::xtf_sss_ping_side& sensor, const Eigen::MatrixXd& hits,
+ping_draping_result BaseDraper::project_ping_side(const std_data::sss_ping_side& sensor, const Eigen::MatrixXd& hits,
                                                   const Eigen::MatrixXd& hits_normals, const Eigen::Vector3d& origin,
                                                   int nbr_bins)
 {

--- a/src/bathy_maps/src/map_draper.cpp
+++ b/src/bathy_maps/src/map_draper.cpp
@@ -18,7 +18,7 @@ template class MapDraper<sss_map_image_builder>;
 template class MapDraper<sss_meas_data_builder>;
 
 sss_map_image::ImagesT drape_maps(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F,
-                                  const BaseDraper::BoundsT& bounds, const xtf_sss_ping::PingsT& pings,
+                                  const BaseDraper::BoundsT& bounds, const std_data::sss_ping::PingsT& pings,
                                   const csv_asvp_sound_speed::EntriesT& sound_speeds, double sensor_yaw,
                                   double resolution, const std::function<void(sss_map_image)>& save_callback)
 {

--- a/src/bathy_maps/src/patch_draper.cpp
+++ b/src/bathy_maps/src/patch_draper.cpp
@@ -16,11 +16,10 @@
 //#include <bathy_maps/drape_mesh.h>
 
 using namespace std;
-using namespace xtf_data;
 using namespace csv_data;
 
 PatchDraper::PatchDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
-                         const xtf_sss_ping::PingsT& pings,
+                         const std_data::sss_ping::PingsT& pings,
                          const BoundsT& bounds,
                          const csv_asvp_sound_speed::EntriesT& sound_speeds)
     : ViewDraper(V1, F1, pings, bounds, sound_speeds), save_callback(&default_callback)
@@ -58,7 +57,7 @@ void PatchDraper::handle_patches()
 }
 */
 
-bool PatchDraper::point_in_view(const xtf_sss_ping& ping, const Eigen::Vector3d& point, double sensor_yaw)
+bool PatchDraper::point_in_view(const std_data::sss_ping& ping, const Eigen::Vector3d& point, double sensor_yaw)
 {
     //Eigen::Matrix3d Ry = Eigen::AngleAxisd(ping.pitch_, Eigen::Vector3d::UnitY()).matrix();
     Eigen::Matrix3d Rcomp = Eigen::AngleAxisd(sensor_yaw, Eigen::Vector3d::UnitZ()).matrix();
@@ -218,7 +217,7 @@ sss_patch_views::ViewsT PatchDraper::get_patch_views()
 }
 
 sss_patch_views::ViewsT drape_patches(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F,
-                                      const PatchDraper::BoundsT& bounds, const xtf_sss_ping::PingsT& pings,
+                                      const PatchDraper::BoundsT& bounds, const std_data::sss_ping::PingsT& pings,
                                       const csv_asvp_sound_speed::EntriesT& sound_speeds, double sensor_yaw,
                                       const std::function<void(sss_patch_views)>& save_callback)
 {

--- a/src/bathy_maps/src/sss_gen_sim.cpp
+++ b/src/bathy_maps/src/sss_gen_sim.cpp
@@ -289,14 +289,6 @@ void SSSGenSim::construct_model_waterfall(const Eigen::MatrixXd& hits_left, cons
     }
 }
 
-// actually we do not need this, already have it from waterfall??????
-/*
-Eigen::MatrixXd draw_gt_waterfall(const xtf_data::xtf_sss_ping& pings)
-{
-
-}
-*/
-
 // NOTE: sss_ping_duration should be the same as for the pings
 Eigen::MatrixXd SSSGenSim::draw_sim_waterfall(const Eigen::MatrixXd& incidence_image)
 {

--- a/src/bathy_maps/src/sss_gen_sim.cpp
+++ b/src/bathy_maps/src/sss_gen_sim.cpp
@@ -19,11 +19,10 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 using namespace std;
-using namespace xtf_data;
 using namespace csv_data;
 
 SSSGenSim::SSSGenSim(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
-                     const xtf_sss_ping::PingsT& pings,
+                     const std_data::sss_ping::PingsT& pings,
                      const BoundsT& bounds,
                      const csv_asvp_sound_speed::EntriesT& sound_speeds,
                      const Eigen::MatrixXd& height_map)

--- a/src/bathy_maps/src/sss_map_image.cpp
+++ b/src/bathy_maps/src/sss_map_image.cpp
@@ -15,7 +15,6 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 using namespace std;
-using namespace xtf_data;
 
 sss_map_image_builder::sss_map_image_builder(const sss_map_image::BoundsT& bounds, double resolution, int nbr_pings) : 
     bounds(bounds), resolution(resolution), waterfall_width(2*nbr_pings), waterfall_counter(0)
@@ -102,7 +101,7 @@ sss_map_image sss_map_image_builder::finish()
 }
 
 void sss_map_image_builder::add_waterfall_images(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
-                                                 const xtf_sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left)
+                                                 const std_data::sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left)
 {
     if (waterfall_counter >= sss_waterfall_image.rows()) {
         sss_waterfall_image.conservativeResize(sss_waterfall_image.rows()+1000, sss_waterfall_image.cols());
@@ -140,7 +139,7 @@ void sss_map_image_builder::add_waterfall_images(const Eigen::MatrixXd& hits, co
 }
 
 void sss_map_image_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
-                                     const xtf_sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left)
+                                     const std_data::sss_ping_side& ping, const Eigen::Vector3d& pos, bool is_left)
 {
     if (hits.rows() == 0) {
         return;
@@ -176,7 +175,7 @@ void sss_map_image_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::V
 void sss_map_image_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
                                      const Eigen::VectorXd& intensities,
                                      const Eigen::VectorXd& sss_depths, const Eigen::VectorXd& sss_model,
-                                     const xtf_sss_ping_side& ping, const Eigen::Vector3d& pos,
+                                     const std_data::sss_ping_side& ping, const Eigen::Vector3d& pos,
                                      const Eigen::Vector3d& rpy, bool is_left)
 {
     /*

--- a/src/bathy_maps/src/sss_meas_data.cpp
+++ b/src/bathy_maps/src/sss_meas_data.cpp
@@ -15,7 +15,6 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 using namespace std;
-using namespace xtf_data;
 
 sss_meas_data_builder::sss_meas_data_builder(const sss_meas_data::BoundsT& bounds, double resolution, int nbr_pings) : 
     waterfall_width(2*nbr_pings), waterfall_counter(0)
@@ -101,7 +100,7 @@ sss_meas_data sss_meas_data_builder::finish()
 void sss_meas_data_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::VectorXi& hits_inds,
                                      const Eigen::VectorXd& intensities,
                                      const Eigen::VectorXd& sss_depths, const Eigen::VectorXd& sss_model,
-                                     const xtf_sss_ping_side& ping, const Eigen::Vector3d& current_pos,
+                                     const std_data::sss_ping_side& ping, const Eigen::Vector3d& current_pos,
                                      const Eigen::Vector3d& current_rpy, bool is_left)
 {
     if (!is_left) {

--- a/src/bathy_maps/src/view_draper.cpp
+++ b/src/bathy_maps/src/view_draper.cpp
@@ -3,11 +3,10 @@
 #include <igl/readSTL.h>
 
 using namespace std;
-using namespace xtf_data;
 using namespace csv_data;
 
 ViewDraper::ViewDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
-                       const xtf_sss_ping::PingsT& pings,
+                       const std_data::sss_ping::PingsT& pings,
                        const BoundsT& bounds,
                        const csv_asvp_sound_speed::EntriesT& sound_speeds)
     : BaseDraper(V1, F1, bounds, sound_speeds), pings(pings), i(0), nbr_time_bins(256)
@@ -169,7 +168,7 @@ Eigen::MatrixXd color_jet_from_mesh(const Eigen::MatrixXd& V)
 }
 
 void drape_viewer(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F,
-                  const ViewDraper::BoundsT& bounds, const xtf_sss_ping::PingsT& pings,
+                  const ViewDraper::BoundsT& bounds, const std_data::sss_ping::PingsT& pings,
                   const csv_asvp_sound_speed::EntriesT& sound_speeds, double sensor_yaw)
 {
     Eigen::MatrixXd Vb;

--- a/src/data_tools/CMakeLists.txt
+++ b/src/data_tools/CMakeLists.txt
@@ -121,7 +121,7 @@ target_link_libraries(benchmark PUBLIC eigen_cereal std_data ${OpenCV_LIBS})
 
 target_link_libraries(navi_data PUBLIC eigen_cereal data_transforms) # ${PCL_LIBRARIES})
 
-target_link_libraries(csv_data PUBLIC std_data navi_data xtf_data)
+target_link_libraries(csv_data PUBLIC std_data navi_data)
 
 if(AUVLIB_WITH_GSF)
   target_link_libraries(gsf_data PUBLIC gsf std_data navi_data lat_long_utm csv_data)

--- a/src/data_tools/include/data_tools/csv_data.h
+++ b/src/data_tools/include/data_tools/csv_data.h
@@ -14,7 +14,7 @@
 
 #include <data_tools/std_data.h>
 #include <data_tools/navi_data.h>
-#include <data_tools/xtf_data.h>
+//#include <data_tools/xtf_data.h>
 
 namespace csv_data {
 
@@ -76,7 +76,7 @@ struct csv_asvp_sound_speed
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
-xtf_data::xtf_sss_ping::PingsT convert_matched_entries(xtf_data::xtf_sss_ping::PingsT& pings, csv_data::csv_nav_entry::EntriesT& entries);
+std_data::sss_ping::PingsT convert_matched_entries(std_data::sss_ping::PingsT& pings, csv_data::csv_nav_entry::EntriesT& entries);
 
 } // namespace csv_data
 

--- a/src/data_tools/include/data_tools/jsf_data.h
+++ b/src/data_tools/include/data_tools/jsf_data.h
@@ -13,7 +13,7 @@
 #define JSF_DATA_H
 
 #include <data_tools/std_data.h>
-#include <data_tools/xtf_data.h>
+//#include <data_tools/xtf_data.h>
 #include <libjsf/jsf.h>
 #include <Eigen/Dense>
 #define BOOST_NO_CXX11_SCOPED_ENUMS
@@ -104,7 +104,7 @@ struct jsf_dvl_ping
 cv::Mat make_waterfall_image(const jsf_sss_ping::PingsT& pings);
 void show_waterfall_image(const jsf_sss_ping::PingsT& pings);
 jsf_sss_ping::PingsT filter_frequency(const jsf_sss_ping::PingsT& pings, int desired_freq);
-xtf_data::xtf_sss_ping::PingsT convert_to_xtf_pings(const jsf_sss_ping::PingsT& pings);
+std_data::sss_ping::PingsT convert_to_xtf_pings(const jsf_sss_ping::PingsT& pings);
 
 
 } // namespace jsf_data

--- a/src/data_tools/include/data_tools/std_data.h
+++ b/src/data_tools/include/data_tools/std_data.h
@@ -65,6 +65,49 @@ struct mbes_ping
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
+struct sss_ping_side
+{
+    std::vector<int> pings;
+    double slant_range;
+    double time_duration;
+    double tilt_angle;
+    double beam_width;
+
+	template <class Archive>
+    void serialize( Archive & ar )
+    {
+        ar(CEREAL_NVP(pings), CEREAL_NVP(slant_range), CEREAL_NVP(time_duration), CEREAL_NVP(tilt_angle), CEREAL_NVP(beam_width));
+    }
+};
+
+struct sss_ping
+{
+    using PingsT = std::vector<sss_ping, Eigen::aligned_allocator<sss_ping> >;
+
+    std::string time_string_; // readable time stamp string
+    long long time_stamp_; // posix time stamp
+
+    sss_ping_side port;
+    sss_ping_side stbd;
+    bool first_in_file_;
+    double heading_;
+    double pitch_;
+    double roll_;
+    double lat_;
+    double long_;
+    double sound_vel_;
+    Eigen::Vector3d pos_; // NOTE: this comes from associating ping with nav data
+
+	template <class Archive>
+    void serialize( Archive & ar )
+    {
+        ar(CEREAL_NVP(time_string_), CEREAL_NVP(time_stamp_), CEREAL_NVP(port), CEREAL_NVP(stbd), CEREAL_NVP(first_in_file_), CEREAL_NVP(heading_),
+           CEREAL_NVP(pitch_), CEREAL_NVP(roll_), CEREAL_NVP(lat_), CEREAL_NVP(long_), CEREAL_NVP(sound_vel_), CEREAL_NVP(pos_));
+    }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
 struct nav_entry
 {
     // data structure used to store a collection of nav_entries

--- a/src/data_tools/include/data_tools/xtf_data.h
+++ b/src/data_tools/include/data_tools/xtf_data.h
@@ -21,48 +21,36 @@
 
 namespace xtf_data {
 
-struct xtf_sss_ping_side
-{
-    std::vector<int> pings;
-    double slant_range;
-    double time_duration;
-    double tilt_angle;
-    double beam_width;
+// the xtf pings and std pings are the same
+using xtf_sss_ping_side = std_data::sss_ping_side;
+using xtf_sss_ping = std_data::sss_ping;
+
+/*
+struct xtf_sss_ping_side : public std_data::sss_ping_side {
 
 	template <class Archive>
     void serialize( Archive & ar )
     {
-        ar(CEREAL_NVP(pings), CEREAL_NVP(slant_range), CEREAL_NVP(time_duration), CEREAL_NVP(tilt_angle), CEREAL_NVP(beam_width));
+        ar(cereal::base_class<std_data::sss_ping_side>( this ));
     }
+
 };
+*/
 
-struct xtf_sss_ping
-{
-    using PingsT = std::vector<xtf_sss_ping, Eigen::aligned_allocator<xtf_sss_ping> >;
+/*
+struct xtf_sss_ping : public std_data::sss_ping {
 
-    std::string time_string_; // readable time stamp string
-    long long time_stamp_; // posix time stamp
-
-    xtf_sss_ping_side port;
-    xtf_sss_ping_side stbd;
-    bool first_in_file_;
-    double heading_;
-    double pitch_;
-    double roll_;
-    double lat_;
-    double long_;
-    double sound_vel_;
-    Eigen::Vector3d pos_; // NOTE: this comes from associating ping with nav data
+    //using PingsT = std::vector<xtf_sss_ping, Eigen::aligned_allocator<xtf_sss_ping> >;
 
 	template <class Archive>
     void serialize( Archive & ar )
     {
-        ar(CEREAL_NVP(time_string_), CEREAL_NVP(time_stamp_), CEREAL_NVP(port), CEREAL_NVP(stbd), CEREAL_NVP(first_in_file_), CEREAL_NVP(heading_),
-           CEREAL_NVP(pitch_), CEREAL_NVP(roll_), CEREAL_NVP(lat_), CEREAL_NVP(long_), CEREAL_NVP(sound_vel_), CEREAL_NVP(pos_));
+        ar(cereal::base_class<std_data::sss_ping>( this ));
     }
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
+*/
 
 cv::Mat make_waterfall_image(const xtf_sss_ping::PingsT& pings);
 Eigen::MatrixXd make_eigen_waterfall_image(const xtf_sss_ping::PingsT& pings);

--- a/src/data_tools/src/csv_data.cpp
+++ b/src/data_tools/src/csv_data.cpp
@@ -10,7 +10,7 @@
  */
 
 #include <data_tools/csv_data.h>
-#include <data_tools/xtf_data.h>
+//#include <data_tools/xtf_data.h>
 
 #define BOOST_NO_CXX11_SCOPED_ENUMS
 #include <boost/date_time.hpp>
@@ -28,23 +28,22 @@ inline std::basic_istream<Char, Traits>& skip(std::basic_istream<Char, Traits>& 
 namespace csv_data {
 
 using namespace std_data;
-using namespace xtf_data;
 
-xtf_sss_ping::PingsT convert_matched_entries_pitch(xtf_sss_ping::PingsT& pings, csv_nav_entry::EntriesT& entries)
+std_data::sss_ping::PingsT convert_matched_entries_pitch(std_data::sss_ping::PingsT& pings, csv_nav_entry::EntriesT& entries)
 {
-    xtf_sss_ping::PingsT new_pings;
+    std_data::sss_ping::PingsT new_pings;
 
     std::stable_sort(entries.begin(), entries.end(), [](const csv_nav_entry& entry1, const csv_nav_entry& entry2) {
         return entry1.time_stamp_ < entry2.time_stamp_;
     });
 
     auto pos = entries.begin();
-    for (xtf_sss_ping& ping : pings) {
+    for (std_data::sss_ping& ping : pings) {
         pos = std::find_if(pos, entries.end(), [&](const csv_nav_entry& entry) {
             return entry.time_stamp_ > ping.time_stamp_;
         });
 
-        xtf_sss_ping new_ping = ping;
+        std_data::sss_ping new_ping = ping;
         if (pos == entries.end()) {
             new_ping.pitch_ = entries.back().pitch_;
         }
@@ -65,15 +64,15 @@ xtf_sss_ping::PingsT convert_matched_entries_pitch(xtf_sss_ping::PingsT& pings, 
     return new_pings;
 }
 
-xtf_sss_ping::PingsT convert_matched_entries(xtf_sss_ping::PingsT& pings, csv_nav_entry::EntriesT& entries)
+std_data::sss_ping::PingsT convert_matched_entries(std_data::sss_ping::PingsT& pings, csv_nav_entry::EntriesT& entries)
 {
-    xtf_sss_ping::PingsT new_pings;
+    std_data::sss_ping::PingsT new_pings;
 
     std::stable_sort(entries.begin(), entries.end(), [](const csv_nav_entry& entry1, const csv_nav_entry& entry2) {
         return entry1.time_stamp_ < entry2.time_stamp_;
     });
 
-    std::stable_sort(pings.begin(), pings.end(), [](const xtf_sss_ping& ping1, const xtf_sss_ping& ping2) {
+    std::stable_sort(pings.begin(), pings.end(), [](const std_data::sss_ping& ping1, const std_data::sss_ping& ping2) {
         return ping1.time_stamp_ < ping2.time_stamp_;
     });
 
@@ -81,12 +80,12 @@ xtf_sss_ping::PingsT convert_matched_entries(xtf_sss_ping::PingsT& pings, csv_na
     int bcount = 0;
     int ecount = 0;
     int mcount = 0;
-    for (xtf_sss_ping& ping : pings) {
+    for (std_data::sss_ping& ping : pings) {
         pos = std::find_if(pos, entries.end(), [&](const csv_nav_entry& entry) {
             return entry.time_stamp_ > ping.time_stamp_;
         });
 
-        xtf_sss_ping new_ping = ping;
+        std_data::sss_ping new_ping = ping;
         if (pos == entries.end()) {
             new_ping.roll_ = entries.back().roll_;
             new_ping.pitch_ = entries.back().pitch_;

--- a/src/data_tools/src/jsf_data.cpp
+++ b/src/data_tools/src/jsf_data.cpp
@@ -324,13 +324,13 @@ jsf_dvl_ping read_datagram<jsf_dvl_ping, jsf_dvl_msg_header>(std::ifstream& inpu
 
 }
 
-xtf_data::xtf_sss_ping::PingsT convert_to_xtf_pings(const jsf_sss_ping::PingsT& pings)
+std_data::sss_ping::PingsT convert_to_xtf_pings(const jsf_sss_ping::PingsT& pings)
 {
-    xtf_data::xtf_sss_ping::PingsT converted;
+    std_data::sss_ping::PingsT converted;
     converted.reserve(pings.size());
 
     for (const jsf_sss_ping& ping : pings) {
-        xtf_data::xtf_sss_ping cping;
+        std_data::sss_ping cping;
         cping.time_stamp_ = ping.time_stamp_;
         cping.time_string_ = ping.time_string_;
         cping.first_in_file_ = ping.first_in_file_;

--- a/src/data_tools/src/std_data.cpp
+++ b/src/data_tools/src/std_data.cpp
@@ -22,11 +22,13 @@ namespace std_data {
 // instantiate all versions needed to read the structs
 template nav_entry::EntriesT read_data<nav_entry::EntriesT>(const boost::filesystem::path& path);
 template mbes_ping::PingsT read_data<mbes_ping::PingsT>(const boost::filesystem::path& path);
+template sss_ping::PingsT read_data<sss_ping::PingsT>(const boost::filesystem::path& path);
 template pt_submaps read_data<pt_submaps>(const boost::filesystem::path& path);
 
 // instantiate all versions needed to write the structs
 template void write_data<nav_entry::EntriesT>(nav_entry::EntriesT& data, const boost::filesystem::path& path);
 template void write_data<mbes_ping::PingsT>(mbes_ping::PingsT& data, const boost::filesystem::path& path);
+template void write_data<sss_ping::PingsT>(sss_ping::PingsT& data, const boost::filesystem::path& path);
 template void write_data<pt_submaps>(pt_submaps& data, const boost::filesystem::path& path);
 
 std::string time_string_from_time_stamp(long long time_stamp_)

--- a/src/pybathy_maps/src/pymap_draper.cpp
+++ b/src/pybathy_maps/src/pymap_draper.cpp
@@ -19,7 +19,6 @@
 #include <pybind11/functional.h>
 
 using namespace std_data;
-using namespace xtf_data;
 using namespace csv_data;
 
 namespace py = pybind11;
@@ -81,7 +80,7 @@ PYBIND11_MODULE(map_draper, m) {
     py::class_<MapImageDraper>(m, "MapDraper", "Class for draping the whole data set of sidescan pings onto a bathymetry mesh")
         // Methods inherited from MapImageDraper:
         .def(py::init<const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                      const xtf_sss_ping::PingsT&, const MapImageDraper::BoundsT&,
+                      const std_data::sss_ping::PingsT&, const MapImageDraper::BoundsT&,
                       const csv_asvp_sound_speed::EntriesT&>())
         .def("set_sidescan_yaw", &MapImageDraper::set_sidescan_yaw, "Set yaw correction of sidescan with respect to nav frame")
         .def("set_sidescan_port_stbd_offsets", &MapImageDraper::set_sidescan_port_stbd_offsets, "Set offsets of sidescan port and stbd sides with respect to nav frame")
@@ -100,7 +99,7 @@ PYBIND11_MODULE(map_draper, m) {
     py::class_<MeasDataDraper>(m, "MeasDataDraper", "Class for draping the whole data set of sidescan pings onto a bathymetry mesh")
         // Methods inherited from MeasDataDraper:
         .def(py::init<const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                      const xtf_sss_ping::PingsT&, const MeasDataDraper::BoundsT&,
+                      const std_data::sss_ping::PingsT&, const MeasDataDraper::BoundsT&,
                       const csv_asvp_sound_speed::EntriesT&>())
         .def("set_sidescan_yaw", &MeasDataDraper::set_sidescan_yaw, "Set yaw correction of sidescan with respect to nav frame")
         .def("set_sidescan_port_stbd_offsets", &MeasDataDraper::set_sidescan_port_stbd_offsets, "Set offsets of sidescan port and stbd sides with respect to nav frame")
@@ -116,7 +115,7 @@ PYBIND11_MODULE(map_draper, m) {
         .def("set_close_when_done", &MeasDataDraper::set_close_when_done, "Set if the draper should close when done draping")
         .def("get_images", &MeasDataDraper::get_images, "Get all the sss_map_image::ImagesT that have been gathered so far");
 
-    m.def("drape_maps", &drape_maps, "Overlay xtf_sss_ping::PingsT sidescan data on a mesh and get sss_map_image::ViewsT");
+    m.def("drape_maps", &drape_maps, "Overlay sss_ping::PingsT sidescan data on a mesh and get sss_map_image::ViewsT");
     m.def("color_jet_from_mesh", &color_jet_from_mesh, "Get a jet color scheme from a vertex matrix");
     m.def("get_vehicle_mesh", &get_vehicle_mesh, "Get vertices, faces, and colors for vehicle");
     m.def("convert_maps_to_patches", &convert_maps_to_patches, "Convert sss_map_image::ImagesT to sss_patch_views::ViewsT");

--- a/src/pybathy_maps/src/pypatch_draper.cpp
+++ b/src/pybathy_maps/src/pypatch_draper.cpp
@@ -18,7 +18,6 @@
 #include <pybind11/functional.h>
 
 using namespace std_data;
-using namespace xtf_data;
 using namespace csv_data;
 
 namespace py = pybind11;
@@ -37,7 +36,7 @@ PYBIND11_MODULE(patch_draper, m) {
 
     py::class_<ViewDraper>(m, "ViewDraper", "Base class for draping sidescan pings onto a bathymetry mesh")
         .def(py::init<const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                      const xtf_sss_ping::PingsT&, const ViewDraper::BoundsT&,
+                      const std_data::sss_ping::PingsT&, const ViewDraper::BoundsT&,
                       const csv_asvp_sound_speed::EntriesT&>())
         .def("add_texture_intensities", &ViewDraper::add_texture_intensities, "Add the intensities of draping result hits and intensities")
         .def("get_texture_image", &ViewDraper::get_texture_image, "Get the texture image, defined within bounds, with resolution of 1m")
@@ -52,7 +51,7 @@ PYBIND11_MODULE(patch_draper, m) {
     py::class_<PatchDraper>(m, "PatchDraper", "Base class for draping sidescan pings onto a particular point of a bathymetry mesh")
         // Methods inherited from draping_generator:
         .def(py::init<const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                      const xtf_sss_ping::PingsT&, const PatchDraper::BoundsT&,
+                      const std_data::sss_ping::PingsT&, const PatchDraper::BoundsT&,
                       const csv_asvp_sound_speed::EntriesT&>())
         .def("set_sidescan_yaw", &PatchDraper::set_sidescan_yaw, "Set yaw correction of sidescan with respect to nav frame")
         .def("set_sidescan_port_stbd_offsets", &PatchDraper::set_sidescan_port_stbd_offsets, "Set offsets of sidescan port and stbd sides with respect to nav frame")
@@ -64,9 +63,9 @@ PYBIND11_MODULE(patch_draper, m) {
         .def("set_patch_callback", &PatchDraper::set_patch_callback, "Set the function to be called when all views of a patch have been assembled")
         .def("get_patch_views", &PatchDraper::get_patch_views, "Get all the sss_patch_views::PatchesT that have been gathered so far");
 
-    m.def("drape_patches", &drape_patches, "Overlay xtf_sss_ping::PingsT sidescan data on a mesh and get sss_patch_views::ViewsT");
+    m.def("drape_patches", &drape_patches, "Overlay std_data::sss_ping::PingsT sidescan data on a mesh and get sss_patch_views::ViewsT");
     m.def("color_jet_from_mesh", &color_jet_from_mesh, "Get a jet color scheme from a vertex matrix");
     m.def("get_vehicle_mesh", &get_vehicle_mesh, "Get vertices, faces, and colors for vehicle");
-    m.def("drape_viewer", &drape_viewer, "Overlay xtf_sss_ping::PingsT sidescan data on a mesh and get sss_patch_views::ViewsT");
+    m.def("drape_viewer", &drape_viewer, "Overlay std_data::sss_ping::PingsT sidescan data on a mesh and get sss_patch_views::ViewsT");
     m.def("write_data", &write_data_from_str<sss_patch_views::ViewsT>, "Write sss_patch_views::ViewsT to .cereal file");
 }

--- a/src/pybathy_maps/src/pysss_gen_sim.cpp
+++ b/src/pybathy_maps/src/pysss_gen_sim.cpp
@@ -18,7 +18,6 @@
 #include <pybind11/functional.h>
 
 using namespace std_data;
-using namespace xtf_data;
 using namespace csv_data;
 
 namespace py = pybind11;
@@ -29,7 +28,7 @@ PYBIND11_MODULE(sss_gen_sim, m) {
     py::class_<SSSGenSim>(m, "SSSGenSim", "Class for simulating sidescan pings from a bathymetry mesh")
         // Methods inherited from BaseDraper:
         .def(py::init<const Eigen::MatrixXd&, const Eigen::MatrixXi&,
-                      const xtf_sss_ping::PingsT&, const SSSGenSim::BoundsT&,
+                      const std_data::sss_ping::PingsT&, const SSSGenSim::BoundsT&,
                       const csv_asvp_sound_speed::EntriesT&, const Eigen::MatrixXd&>())
         .def("set_sidescan_yaw", &SSSGenSim::set_sidescan_yaw, "Set yaw correction of sidescan with respect to nav frame")
         .def("set_sidescan_port_stbd_offsets", &SSSGenSim::set_sidescan_port_stbd_offsets, "Set offsets of sidescan port and stbd sides with respect to nav frame")

--- a/src/pydata_tools/src/pyall_data.cpp
+++ b/src/pydata_tools/src/pyall_data.cpp
@@ -102,7 +102,7 @@ PYBIND11_MODULE(all_data, m) {
     m.def("write_data", &write_data_from_str<all_nav_attitude::EntriesT>, "Write all_nav_attitude::EntriesT to .cereal file");
     m.def("write_data", &write_data_from_str<all_echosounder_depth::EntriesT>, "Write all_echosounder_depth::EntriesT to .cereal file");
     //m.def("convert_matched_entries", (all_mbes_ping::PingsT (*)(all_mbes_ping::PingsT&, all_nav_entry::EntriesT&) ) &convert_matched_entries, "Matches xtf_sss_ping::PingsT and csv_nav_entry::EntriesT and assign pos data to pings");
-    m.def("convert_matched_entries", &convert_matched_entries, "Matches xtf_sss_ping::PingsT and csv_nav_entry::EntriesT and assign pos data to pings");
+    m.def("convert_matched_entries", &convert_matched_entries, "Matches all_mbes_ping::PingsT and all_nav_entry::EntriesT and assign pos data to pings");
     m.def("match_attitude", &match_attitude, "Match mbes_ping::PingsT and all_nav_attitude::EntriesT and assign attitude data to pings");
     m.def("convert_sound_speeds", &convert_sound_speeds, "Convert all_mbes_ping::PingsT to csv_asvp_sound_speed::EntriesT");
     m.def("convert_attitudes", &convert_attitudes, "Convert all_nav_attitude::EntriesT to std_data::attitude_entry::EntriesT");

--- a/src/pydata_tools/src/pycsv_data.cpp
+++ b/src/pydata_tools/src/pycsv_data.cpp
@@ -56,5 +56,5 @@ PYBIND11_MODULE(csv_data, m) {
 
     m.def("write_data", &write_data_from_str<csv_nav_entry::EntriesT>, "Write csv_nav_entry::EntriesT to .cereal file");
     m.def("write_data", &write_data_from_str<csv_asvp_sound_speed::EntriesT>, "Write csv_asvp_sound_speed::EntriesT to .cereal file");
-    m.def("convert_matched_entries", (xtf_data::xtf_sss_ping::PingsT (*)(xtf_data::xtf_sss_ping::PingsT&, csv_nav_entry::EntriesT&) ) &convert_matched_entries, "Match xtf_sss_ping::PingsT and csv_nav_entry::EntriesT and assign pos info to pings");
+    m.def("convert_matched_entries", (std_data::sss_ping::PingsT (*)(std_data::sss_ping::PingsT&, csv_nav_entry::EntriesT&) ) &convert_matched_entries, "Match xtf_sss_ping::PingsT and csv_nav_entry::EntriesT and assign pos info to pings");
 }

--- a/src/pydata_tools/src/pyjsf_data.cpp
+++ b/src/pydata_tools/src/pyjsf_data.cpp
@@ -51,7 +51,7 @@ PYBIND11_MODULE(jsf_data, m) {
     m.def("make_waterfall_image", &make_waterfall_image, "Create a cv2 waterfall image from jsf_sss_ping::PingsT");
     m.def("show_waterfall_image", &show_waterfall_image, "Show a waterfall image created from jsf_sss_ping::PingsT");
     m.def("filter_frequency", &filter_frequency, "Filter to keep only jsf_sss_ping::PingsT with certain frequency");
-    m.def("convert_to_xtf_pings", &convert_to_xtf_pings, "Convert jsf_sss_ping::PingsT to xtf_data::xtf_sss_ping::PingsT");
+    m.def("convert_to_xtf_pings", &convert_to_xtf_pings, "Convert jsf_sss_ping::PingsT to std_data::sss_ping::PingsT");
 
     // from http://alexsm.com/pybind11-buffer-protocol-opencv-to-numpy/
     pybind11::class_<cv::Mat>(m, "Image", pybind11::buffer_protocol())

--- a/src/pydata_tools/src/pystd_data.cpp
+++ b/src/pydata_tools/src/pystd_data.cpp
@@ -61,8 +61,33 @@ PYBIND11_MODULE(std_data, m) {
         .def_readwrite("heave", &attitude_entry::heave, "Heave")
         .def_static("read_data", &read_data_from_str<attitude_entry::EntriesT>, "Read attitude_entry::Entries from .cereal file");
 
+    py::class_<std_data::sss_ping_side>(m, "sss_ping_side", "Class for one xtf sidescan side")
+        .def(py::init<>())
+        .def_readwrite("pings", &std_data::sss_ping_side::pings, "The return intensities")
+        .def_readwrite("slant_range", &std_data::sss_ping_side::slant_range, "Slant range")
+        .def_readwrite("time_duration", &std_data::sss_ping_side::time_duration, "Furthest measured intensity")
+        .def_readwrite("tilt_angle", &std_data::sss_ping_side::tilt_angle, "Tilt angle")
+        .def_readwrite("beam_width", &std_data::sss_ping_side::beam_width, "Beam width");
+
+    py::class_<std_data::sss_ping>(m, "sss_ping", "Class for xtf sidescan type")
+        .def(py::init<>())
+        .def_readwrite("time_string_", &std_data::sss_ping::time_string_, "Readable date of measurement")
+        .def_readwrite("time_stamp_", &std_data::sss_ping::time_stamp_, "UNIX timestamp")
+        .def_readwrite("port", &std_data::sss_ping::port, "Port measurement")
+        .def_readwrite("stbd", &std_data::sss_ping::stbd, "Starboard measurement")
+        .def_readwrite("first_in_file_", &std_data::sss_ping::first_in_file_, "Is first measurement in file?")
+        .def_readwrite("heading_", &std_data::sss_ping::heading_, "Radian yaw in ENU coordinates")
+        .def_readwrite("pitch_", &std_data::sss_ping::pitch_, "Radian pitch in ENU coordinates")
+        .def_readwrite("roll_", &std_data::sss_ping::roll_, "Radian roll in ENU coordinates")
+        .def_readwrite("lat_", &std_data::sss_ping::lat_, "Latitude")
+        .def_readwrite("long_", &std_data::sss_ping::long_, "Longitude")
+        .def_readwrite("sound_vel_", &std_data::sss_ping::sound_vel_, "Sound speed in m/s")
+        .def_readwrite("pos_", &std_data::sss_ping::pos_, "Position in ENU coordinates")
+        .def_static("read_data", &read_data_from_str<std_data::sss_ping::PingsT>, "Read sss_ping::PingsT from .cereal file");
+
     m.def("write_data", &write_data_from_str<mbes_ping::PingsT>, "Write mbes_ping::PingsT to .cereal file");
     m.def("write_data", &write_data_from_str<nav_entry::EntriesT>, "Write nav_entry::EntriesT to .cereal file");
     m.def("write_data", &write_data_from_str<attitude_entry::EntriesT>, "Write attitude_entry::EntriesT to .cereal file");
+    m.def("write_data", &write_data_from_str<sss_ping::PingsT>, "Write sss_ping::PingsT to .cereal file");
 
 }

--- a/src/pydata_tools/src/pyxtf_data.cpp
+++ b/src/pydata_tools/src/pyxtf_data.cpp
@@ -23,7 +23,7 @@ namespace py = pybind11;
 PYBIND11_MODULE(xtf_data, m) {
     m.doc() = "Basic utilities for working with the xtf file format"; // optional module docstring
 
-    py::class_<xtf_sss_ping_side>(m, "xtf_sss_ping_side", "Class for one xtf sidescan side")
+    py::class_<xtf_sss_ping_side>(m, "xtf_sss_ping_side", py::module_local(), "Class for one xtf sidescan side")
         .def(py::init<>())
         .def_readwrite("pings", &xtf_sss_ping_side::pings, "The return intensities")
         .def_readwrite("slant_range", &xtf_sss_ping_side::slant_range, "Slant range")
@@ -31,7 +31,7 @@ PYBIND11_MODULE(xtf_data, m) {
         .def_readwrite("tilt_angle", &xtf_sss_ping_side::tilt_angle, "Tilt angle")
         .def_readwrite("beam_width", &xtf_sss_ping_side::beam_width, "Beam width");
 
-    py::class_<xtf_sss_ping>(m, "xtf_sss_ping", "Class for xtf sidescan type")
+    py::class_<xtf_sss_ping>(m, "xtf_sss_ping", py::module_local(), "Class for xtf sidescan type")
         .def(py::init<>())
         .def_readwrite("time_string_", &xtf_sss_ping::time_string_, "Readable date of measurement")
         .def_readwrite("time_stamp_", &xtf_sss_ping::time_stamp_, "UNIX timestamp")


### PR DESCRIPTION
This replaces `xtf_data::xtf_sss_ping` with the identical `std_data::sss_ping` in all library interfaces, both cpp and python.