### PR TITLE
Change draping resolution

### DIFF
--- a/src/bathy_maps/include/bathy_maps/base_draper.h
+++ b/src/bathy_maps/include/bathy_maps/base_draper.h
@@ -59,6 +59,7 @@ public:
     using BoundsT = Eigen::Matrix2d;
 
 protected:
+    int nbr_pings = 256;
 
     Eigen::MatrixXd V1; // bathymetry mesh vertices
     Eigen::MatrixXi F1; // bathymetry mesh faces
@@ -91,7 +92,7 @@ protected:
 
     // NOTE: these are new style functions
     std::pair<Eigen::MatrixXd, Eigen::MatrixXd> compute_sss_dirs(const Eigen::Matrix3d& R, double tilt_angle, double beam_width, int nbr_lines);
-    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> project(const std_data::sss_ping& ping);
+    std::tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> project(const std_data::sss_ping& ping, const int nbr_lines=500);
     std::tuple<Eigen::MatrixXd, Eigen::MatrixXd> trace_side(const std_data::sss_ping_side& ping,
                                                             const Eigen::Vector3d& sensor_origin,
                                                             const Eigen::MatrixXd& dirs);

--- a/src/bathy_maps/include/bathy_maps/base_draper.h
+++ b/src/bathy_maps/include/bathy_maps/base_draper.h
@@ -59,7 +59,6 @@ public:
     using BoundsT = Eigen::Matrix2d;
 
 protected:
-    int nbr_pings = 256;
 
     Eigen::MatrixXd V1; // bathymetry mesh vertices
     Eigen::MatrixXi F1; // bathymetry mesh faces

--- a/src/bathy_maps/include/bathy_maps/impl/map_draper.hpp
+++ b/src/bathy_maps/include/bathy_maps/impl/map_draper.hpp
@@ -25,7 +25,7 @@ MapDraper<MapSaver>::MapDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi&
                                const csv_asvp_sound_speed::EntriesT& sound_speeds)
     : ViewDraper(V1, F1, pings, bounds, sound_speeds),
       resolution(30./8.), save_callback(&default_callback),
-      map_image_builder(bounds, 30./8., 256)
+      map_image_builder(bounds, 30./8., nbr_pings)
       //map_image_builder(bounds, 30./8., pings[0].port.pings.size())
 {
     viewer.callback_pre_draw = std::bind(&MapDraper::callback_pre_draw, this, std::placeholders::_1);
@@ -67,7 +67,7 @@ bool MapDraper<MapSaver>::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
             map_images.push_back(map_image);
         }
         //map_image_builder = sss_map_image_builder(bounds, resolution, pings[i].port.pings.size());
-        map_image_builder = MapSaver(bounds, resolution, 256);
+        map_image_builder = MapSaver(bounds, resolution, nbr_pings);
     }
 
     if (i >= pings.size()) {
@@ -78,6 +78,7 @@ bool MapDraper<MapSaver>::callback_pre_draw(igl::opengl::glfw::Viewer& viewer)
     }
 
     ping_draping_result left, right;
+    cout << "Number of waterfall bins: " << map_image_builder.get_waterfall_bins() << endl;
     tie(left, right) = project_ping(pings[i], map_image_builder.get_waterfall_bins());
 
     // add the 3d hits and waterfall images to the builder object
@@ -151,10 +152,17 @@ void MapDraper<MapSaver>::set_resolution(double new_resolution)
 { 
     resolution = new_resolution;
     //map_image_builder = sss_map_image_builder(bounds, resolution, pings[i].port.pings.size());
-    map_image_builder = MapSaver(bounds, resolution, 256);
+    map_image_builder = MapSaver(bounds, resolution, nbr_pings);
     //int rows, cols;
     //tie(rows, cols) = map_image_builder.get_map_image_shape();
     //draping_vis_texture = Eigen::MatrixXd::Zero(rows, cols);
+}
+
+template <typename MapSaver>
+void MapDraper<MapSaver>::set_nbr_pings(int new_nbr_pings)
+{
+    nbr_pings = new_nbr_pings;
+    map_image_builder = MapSaver(bounds, resolution, nbr_pings);
 }
 
 template <typename MapSaver>

--- a/src/bathy_maps/include/bathy_maps/map_draper.h
+++ b/src/bathy_maps/include/bathy_maps/map_draper.h
@@ -25,6 +25,7 @@ public:
 
 protected:
 
+    int nbr_pings = 256; //default nbr_pings per channel //default nbr_pings per channel //default nbr_pings per channel //default nbr_pings per channel
     double resolution;
     std::function<void(MapType)> save_callback;
     typename MapType::ImagesT map_images;
@@ -41,6 +42,9 @@ public:
     void set_resolution(double new_resolution);
     void set_store_map_images(bool store) { store_map_images = store; }
     void set_close_when_done(bool close) { close_when_done = close; }
+
+    void set_nbr_pings(int new_nbr_pings);
+    int get_nbr_pings() {return nbr_pings;}
 
     MapDraper(const Eigen::MatrixXd& V1, const Eigen::MatrixXi& F1,
               const std_data::sss_ping::PingsT& pings,

--- a/src/bathy_maps/include/bathy_maps/map_draper.h
+++ b/src/bathy_maps/include/bathy_maps/map_draper.h
@@ -25,7 +25,7 @@ public:
 
 protected:
 
-    int nbr_pings = 256; //default nbr_pings per channel //default nbr_pings per channel //default nbr_pings per channel //default nbr_pings per channel
+    int nbr_pings = 256; //default nbr_pings per channel
     double resolution;
     std::function<void(MapType)> save_callback;
     typename MapType::ImagesT map_images;

--- a/src/bathy_maps/include/bathy_maps/sss_meas_data.h
+++ b/src/bathy_maps/include/bathy_maps/sss_meas_data.h
@@ -82,6 +82,7 @@ public:
                   const std_data::sss_ping_side& ping, const Eigen::Vector3d& pos,
                   const Eigen::Vector3d& rpy, bool is_left); // used
 
+
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };

--- a/src/bathy_maps/src/base_draper.cpp
+++ b/src/bathy_maps/src/base_draper.cpp
@@ -72,7 +72,7 @@ pair<Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::compute_sss_dirs(const Eigen:
     return make_pair(dirs_left, dirs_right);
 }
 
-tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::project(const std_data::sss_ping& ping)
+tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> BaseDraper::project(const std_data::sss_ping& ping, const int nbr_lines)
 {
     if (DEBUG_OUTPUT) cout << "Setting new position: " << ping.pos_.transpose() << endl;
     Eigen::Matrix3d Rcomp = Eigen::AngleAxisd(sensor_yaw, Eigen::Vector3d::UnitZ()).matrix();
@@ -107,7 +107,7 @@ tuple<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd> BaseDr
 
     Eigen::MatrixXd dirs_left;
     Eigen::MatrixXd dirs_right;
-    tie(dirs_left, dirs_right) = compute_sss_dirs(R, tilt_angle, beam_width, 500);
+    tie(dirs_left, dirs_right) = compute_sss_dirs(R, tilt_angle, beam_width, nbr_lines);
 
     tie(hits_left, normals_left) = trace_side(ping.port, origin_port, dirs_left);
     tie(hits_right, normals_right) = trace_side(ping.stbd, origin_stbd, dirs_right);
@@ -376,7 +376,7 @@ sss_draping_result BaseDraper::project_ping(const std_data::sss_ping& ping, int 
     Eigen::MatrixXd normals_left;
     Eigen::MatrixXd normals_right;
     auto start = chrono::high_resolution_clock::now();
-    tie(hits_left, hits_right, normals_left, normals_right) = project(ping);
+    tie(hits_left, hits_right, normals_left, normals_right) = project(ping, nbr_bins*2);
     auto stop = chrono::high_resolution_clock::now();
     auto duration = chrono::duration_cast<chrono::microseconds>(stop - start);
     if (DEBUG_OUTPUT) cout << "project time: " << duration.count() << " microseconds" << endl;

--- a/src/bathy_maps/src/sss_map_image.cpp
+++ b/src/bathy_maps/src/sss_map_image.cpp
@@ -85,17 +85,10 @@ sss_map_image sss_map_image_builder::finish()
     }
     map_image.sss_ping_duration = sss_ping_duration;
     map_image.pos = poss;
-    if (waterfall_width == 512) {
-        map_image.sss_waterfall_image = sss_waterfall_image.topRows(waterfall_counter).cast<float>();
-        map_image.sss_waterfall_depth = sss_waterfall_depth.topRows(waterfall_counter).cast<float>();
-        map_image.sss_waterfall_model = sss_waterfall_model.topRows(waterfall_counter).cast<float>();
-    }
-    else {
-        map_image.sss_waterfall_image = downsample_cols(sss_waterfall_image.topRows(waterfall_counter), 512).cast<float>();
-        //map_image.sss_waterfall_cross_track = sss_waterfall_cross_track.topRows(waterfall_counter);
-        map_image.sss_waterfall_depth = downsample_cols(sss_waterfall_depth.topRows(waterfall_counter), 512).cast<float>();
-        map_image.sss_waterfall_model = downsample_cols(sss_waterfall_model.topRows(waterfall_counter), 512).cast<float>();
-    }
+
+    map_image.sss_waterfall_image = sss_waterfall_image.topRows(waterfall_counter).cast<float>();
+    map_image.sss_waterfall_depth = sss_waterfall_depth.topRows(waterfall_counter).cast<float>();
+    map_image.sss_waterfall_model = sss_waterfall_model.topRows(waterfall_counter).cast<float>();
 
     return map_image;
 }
@@ -231,34 +224,20 @@ void sss_map_image_builder::add_hits(const Eigen::MatrixXd& hits, const Eigen::V
 
     std::cout << __FILE__ << ", " << __LINE__ << std::endl;
 
-    if (waterfall_width == 512) {
-        double ping_step = double(ping.pings.size()) / double(waterfall_width/2);
-        Eigen::ArrayXd value_windows = Eigen::VectorXd::Zero(waterfall_width/2);
-        Eigen::ArrayXd value_counts = Eigen::ArrayXd::Zero(waterfall_width/2);
-        for (int i = 0; i < ping.pings.size(); ++i) {
-            int col = int(double(i)/ping_step);
-            value_windows(col) += double(ping.pings[i])/10000.;
-            value_counts(col) += 1.;
-        }
-        value_counts += (value_counts == 0).cast<double>();
-        if (is_left) {
-            sss_waterfall_image.block(waterfall_counter, waterfall_width/2, 1, waterfall_width/2) = (value_windows / value_counts).transpose();
-        }
-        else {
-            sss_waterfall_image.block(waterfall_counter, 0, 1, waterfall_width/2) = (value_windows / value_counts).reverse().transpose();
-        }
+    double ping_step = double(ping.pings.size()) / double(waterfall_width/2);
+    Eigen::ArrayXd value_windows = Eigen::VectorXd::Zero(waterfall_width/2);
+    Eigen::ArrayXd value_counts = Eigen::ArrayXd::Zero(waterfall_width/2);
+    for (int i = 0; i < ping.pings.size(); ++i) {
+        int col = int(double(i)/ping_step);
+        value_windows(col) += double(ping.pings[i])/10000.;
+        value_counts(col) += 1.;
+    }
+    value_counts += (value_counts == 0).cast<double>();
+    if (is_left) {
+        sss_waterfall_image.block(waterfall_counter, waterfall_width/2, 1, waterfall_width/2) = (value_windows / value_counts).transpose();
     }
     else {
-        for (int i = 0; i < ping.pings.size(); ++i) {
-            int col;
-            if (is_left) {
-                col = waterfall_width/2 + i;
-            }
-            else {
-                col = waterfall_width/2 - 1 - i;
-            }
-            sss_waterfall_image(waterfall_counter, col) = double(ping.pings[i])/10000.;
-        }
+        sss_waterfall_image.block(waterfall_counter, 0, 1, waterfall_width/2) = (value_windows / value_counts).reverse().transpose();
     }
     std::cout << __FILE__ << ", " << __LINE__ << std::endl;
 

--- a/src/pybathy_maps/src/pymap_draper.cpp
+++ b/src/pybathy_maps/src/pymap_draper.cpp
@@ -71,7 +71,10 @@ PYBIND11_MODULE(map_draper, m) {
         .def("set_image_callback", &MapImageDraper::set_image_callback, "Set the function to be called when an entire sidescan map is done")
         .def("set_store_map_images", &MapImageDraper::set_store_map_images, "Set if the draper should save and return map images at the end")
         .def("set_close_when_done", &MapImageDraper::set_close_when_done, "Set if the draper should close when done draping")
-        .def("get_images", &MapImageDraper::get_images, "Get all the sss_map_image::ImagesT that have been gathered so far");
+        .def("get_images", &MapImageDraper::get_images, "Get all the sss_map_image::ImagesT that have been gathered so far")
+        // Getters and setters for nbr_pings and (indirectly) waterfall_width
+        .def("get_nbr_pings", &MapImageDraper::get_nbr_pings, "Get number of pings in one side-scan channel")
+        .def("set_nbr_pings", &MapImageDraper::set_nbr_pings, "Set desirable number of pings in one side-scan channel (<= nbr_bins in the actual side-scan data)");
 
     py::class_<MeasDataDraper>(m, "MeasDataDraper", "Class for draping the whole data set of sidescan pings onto a bathymetry mesh")
         // Methods inherited from MeasDataDraper:
@@ -90,7 +93,10 @@ PYBIND11_MODULE(map_draper, m) {
         .def("set_image_callback", &MeasDataDraper::set_image_callback, "Set the function to be called when an entire sidescan map is done")
         .def("set_store_map_images", &MeasDataDraper::set_store_map_images, "Set if the draper should save and return map images at the end")
         .def("set_close_when_done", &MeasDataDraper::set_close_when_done, "Set if the draper should close when done draping")
-        .def("get_images", &MeasDataDraper::get_images, "Get all the sss_map_image::ImagesT that have been gathered so far");
+        .def("get_images", &MeasDataDraper::get_images, "Get all the sss_map_image::ImagesT that have been gathered so far")
+        // Getters and setters for nbr_pings and (indirectly) waterfall_width
+        .def("get_nbr_pings", &MeasDataDraper::get_nbr_pings, "Get number of pings in one side-scan channel")
+        .def("set_nbr_pings", &MeasDataDraper::set_nbr_pings, "Set desirable number of pings in one side-scan channel (<= nbr_bins in the actual side-scan data)");
 
     m.def("drape_maps", &drape_maps, "Overlay sss_ping::PingsT sidescan data on a mesh and get sss_map_image::ViewsT");
     m.def("color_jet_from_mesh", &color_jet_from_mesh, "Get a jet color scheme from a vertex matrix");


### PR DESCRIPTION
- Add `nbr_pings` field to MapDrapers (MeasDataDraper and MapImageDraper)
- Add the corresponding `set_nbr_pings`. Calling this method will change the shape of the `sss_meas_data` and `sss_map_image` from draping
- Add an optional argument `nbr_lines` to base_draper's `project` method. When MapDrapers are used to drape, the number of projection lines are set to `2*nbr_pings`