### PR TITLE
Refactor benchmark

### DIFF
--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -77,7 +77,7 @@ struct track_error_benchmark {
     void add_ground_truth(PointsT &map_points, PointsT &track_points);
     void add_benchmark(PointsT &maps_points, PointsT &tracks_points, const std::string &name);
 
-    void track_img_params(PointsT& points_maps, int rows, int cols);
+    void track_img_params(PointsT& points_maps);
     cv::Mat draw_height_map(PointsT &points_maps);
     std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_pings(std_data::mbes_ping::PingsT& pings);
     std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_matrices(PointsT& points_maps);
@@ -89,7 +89,7 @@ struct track_error_benchmark {
     cv::Mat draw_height_submap(PointsT &map_points, PointsT &track_points, const int &submap_number);
     void map_draw_params(PointsT& map_points, PointsT& track_points, const int& submap_number);
 
-    void track_img_params(std_data::mbes_ping::PingsT& pings, int rows=1000, int cols=1000);
+    void track_img_params(std_data::mbes_ping::PingsT& pings);
     void draw_track_img(std_data::mbes_ping::PingsT& pings, cv::Mat& img, const cv::Scalar& color, const std::string& name);
     //void draw_track_img(pt_submaps::TransT& positions);
     void draw_track_legend();

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -46,6 +46,10 @@ struct track_error_benchmark {
     double min_depth_;
     double max_depth_;
 
+    // Benchmark number of rows and columns
+    int benchmark_nbr_rows;
+    int benchmark_nbr_cols;
+
     // TODO: get this from on of the dicts instead
     //int nbr_tracks_drawn;
 
@@ -55,13 +59,8 @@ struct track_error_benchmark {
     // NOTE: this is here for convenience
     cv::Mat track_img;
 
-    track_error_benchmark() : dataset_name("default")
-    {
-        min_consistency_error = -1.;
-        max_consistency_error = -1.;
-    }
-
-    track_error_benchmark(const std::string& dataset_name) : dataset_name(dataset_name)
+    track_error_benchmark(const std::string& dataset_name="default", int nbr_rows=500, int nbr_cols=500) :
+        dataset_name(dataset_name), benchmark_nbr_rows(nbr_rows), benchmark_nbr_cols(nbr_cols)
     {
         min_consistency_error = -1.;
         max_consistency_error = -1.;
@@ -78,7 +77,7 @@ struct track_error_benchmark {
     void add_ground_truth(PointsT &map_points, PointsT &track_points);
     void add_benchmark(PointsT &maps_points, PointsT &tracks_points, const std::string &name);
 
-    void track_img_params(PointsT& points_maps, int rows=1000, int cols=1000);
+    void track_img_params(PointsT& points_maps, int rows, int cols);
     cv::Mat draw_height_map(PointsT &points_maps);
     std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_pings(std_data::mbes_ping::PingsT& pings);
     std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_matrices(PointsT& points_maps);

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -775,7 +775,7 @@ std::pair<double, Eigen::MatrixXd> track_error_benchmark::compute_consistency_er
 
             // Registration error
             double value = 0.;
-            int nbr_averages = 10;
+            int nbr_averages = 1000;
             for (int c = 0; c < nbr_averages; ++c) {
                 double maxm = 0.;
                 for (int m = 0; m < nbr_maps; ++m) {

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -22,7 +22,7 @@ namespace benchmark {
 using namespace std_data;
 
 // res, xmin, ymin, imxmin, imymin
-void track_error_benchmark::track_img_params(mbes_ping::PingsT& pings, int rows, int cols)
+void track_error_benchmark::track_img_params(mbes_ping::PingsT& pings)
 {
     auto xcomp = [](const mbes_ping& p1, const mbes_ping& p2) {
         return p1.pos_[0] < p2.pos_[0];
@@ -37,22 +37,22 @@ void track_error_benchmark::track_img_params(mbes_ping::PingsT& pings, int rows,
 
     cout << "Min X: " << minx << ", Max X: " << maxx << ", Min Y: " << miny << ", Max Y: " << maxy << endl;
 
-    double xres = double(cols)/(maxx - minx);
-    double yres = double(rows)/(maxy - miny);
+    double xres = double(benchmark_nbr_cols)/(maxx - minx);
+    double yres = double(benchmark_nbr_rows)/(maxy - miny);
 
     double res = std::min(xres, yres);
 
-    double x0 = .5*(double(cols) - res*(maxx-minx));
-    double y0 = .5*(double(rows) - res*(maxy-miny));
+    double x0 = .5*(double(benchmark_nbr_cols) - res*(maxx-minx));
+    double y0 = .5*(double(benchmark_nbr_rows) - res*(maxy-miny));
 
     cout << xres << ", " << yres << endl;
 
     params = array<double, 5>{res, minx, miny, x0, y0};
-    track_img = cv::Mat(rows, cols, CV_8UC3, cv::Scalar(255, 255, 255));
+    track_img = cv::Mat(benchmark_nbr_rows, benchmark_nbr_cols, CV_8UC3, cv::Scalar(255, 255, 255));
 }
 
 
-void track_error_benchmark::track_img_params(PointsT& points_maps, int rows, int cols)
+void track_error_benchmark::track_img_params(PointsT& points_maps)
 {
     auto xcomp = [](const Eigen::Vector3d& p1, const Eigen::Vector3d& p2) {
         return p1[0] < p2[0];
@@ -68,18 +68,18 @@ void track_error_benchmark::track_img_params(PointsT& points_maps, int rows, int
 
     cout << "Min X: " << minx << ", Max X: " << maxx << ", Min Y: " << miny << ", Max Y: " << maxy << endl;
 
-    double xres = double(cols)/(maxx - minx);
-    double yres = double(rows)/(maxy - miny);
+    double xres = double(benchmark_nbr_cols)/(maxx - minx);
+    double yres = double(benchmark_nbr_rows)/(maxy - miny);
 
     double res = std::min(xres, yres);
 
-    double x0 = .5*(double(cols) - res*(maxx-minx));
-    double y0 = .5*(double(rows) - res*(maxy-miny));
+    double x0 = .5*(double(benchmark_nbr_cols) - res*(maxx-minx));
+    double y0 = .5*(double(benchmark_nbr_rows) - res*(maxy-miny));
 
     cout << xres << ", " << yres << endl;
 
     params = array<double, 5>{res, minx, miny, x0, y0};
-    track_img = cv::Mat(rows, cols, CV_8UC3, cv::Scalar(255, 255, 255));
+    track_img = cv::Mat(benchmark_nbr_rows, benchmark_nbr_cols, CV_8UC3, cv::Scalar(255, 255, 255));
 }
 
 
@@ -251,18 +251,16 @@ pair<double, cv::Mat> track_error_benchmark::compute_draw_consistency_map(mbes_p
 void track_error_benchmark::map_draw_params(PointsT& map_points, PointsT& track_points,
                                             const int& submap_number){
 
-    int rows = 500;
-    int cols = 500;
     gt_track.clear();
     for(const Eigen::MatrixXd& track_i: track_points){
       for(unsigned int i=0; i<track_i.rows(); i++){
           gt_track.push_back(track_i.row(i));
       }
     }
-    track_img_params(map_points, rows, cols);
+    track_img_params(map_points);
 
-    Eigen::MatrixXd means(rows, cols); means.setZero();
-    Eigen::MatrixXd counts(rows, cols); counts.setZero();
+    Eigen::MatrixXd means(benchmark_nbr_rows, benchmark_nbr_cols); means.setZero();
+    Eigen::MatrixXd counts(benchmark_nbr_rows, benchmark_nbr_cols); counts.setZero();
 
     double res, minx, miny, x0, y0;
     res = params[0]; minx = params[1]; miny = params[2]; x0 = params[3]; y0 = params[4];
@@ -272,7 +270,7 @@ void track_error_benchmark::map_draw_params(PointsT& map_points, PointsT& track_
             Eigen::Vector3d pos = submap.row(i);
             int col = int(x0+res*(pos[0]-minx));
             int row = int(y0+res*(pos[1]-miny));
-            if (col >= 0 && col < cols && row >= 0 && row < rows) {
+            if (col >= 0 && col < benchmark_nbr_cols && row >= 0 && row < benchmark_nbr_rows) {
                 means(row, col) += pos[2];
                 counts(row, col) += 1.;
             }
@@ -383,27 +381,24 @@ cv::Mat track_error_benchmark::draw_height_map(mbes_ping::PingsT& pings)
 cv::Mat track_error_benchmark::draw_height_submap(PointsT& map_points, PointsT& track_points,
                                                   const int& submap_number){
 
-    int rows = 500;
-    int cols = 500;
-
     gt_track.clear();
     for(const Eigen::MatrixXd& track_i: track_points){
         for(unsigned int i=0; i<track_i.rows(); i++){
             gt_track.push_back(track_i.row(i));
         }
     }
-    track_img_params(map_points, rows, cols);
+    track_img_params(map_points);
     double res, minx, miny, x0, y0;
     res = params[0]; minx = params[1]; miny = params[2]; x0 = params[3]; y0 = params[4];
 
-    Eigen::MatrixXd means(rows, cols); means.setZero();
-    Eigen::MatrixXd counts(rows, cols); counts.setZero();
+    Eigen::MatrixXd means(benchmark_nbr_rows, benchmark_nbr_cols); means.setZero();
+    Eigen::MatrixXd counts(benchmark_nbr_rows, benchmark_nbr_cols); counts.setZero();
     for(const Eigen::MatrixXd& submap: map_points){
         for(unsigned int i = 0; i<submap.rows(); i++){
             Eigen::Vector3d pos = submap.row(i);
             int col = int(x0+res*(pos[0]-minx));
             int row = int(y0+res*(pos[1]-miny));
-            if (col >= 0 && col < cols && row >= 0 && row < rows) {
+            if (col >= 0 && col < benchmark_nbr_cols && row >= 0 && row < benchmark_nbr_rows) {
                 means(row, col) += pos[2];
                 counts(row, col) += 1.;
             }
@@ -415,13 +410,13 @@ cv::Mat track_error_benchmark::draw_height_submap(PointsT& map_points, PointsT& 
     means.array() -= min_depth_*(counts.array() > 0).cast<double>();
     means.array() /= max_depth_;
 
-    cv::Mat mean_img = cv::Mat(rows, cols, CV_8UC3, cv::Scalar(255, 255, 255));
-    for (int i = 0; i < rows; ++i) {
-        for (int j = 0; j < cols; ++j) {
+    cv::Mat mean_img = cv::Mat(benchmark_nbr_rows, benchmark_nbr_cols, CV_8UC3, cv::Scalar(255, 255, 255));
+    for (int i = 0; i < benchmark_nbr_rows; ++i) {
+        for (int j = 0; j < benchmark_nbr_cols; ++j) {
             if (means(i, j) == 0) {
                 continue;
             }
-            cv::Point3_<uchar>* p = mean_img.ptr<cv::Point3_<uchar> >(rows-i-1, j);
+            cv::Point3_<uchar>* p = mean_img.ptr<cv::Point3_<uchar> >(benchmark_nbr_rows-i-1, j);
             tie(p->z, p->y, p->x) = jet(means(i, j));
         }
     }
@@ -434,27 +429,21 @@ cv::Mat track_error_benchmark::draw_height_submap(PointsT& map_points, PointsT& 
 
 void track_error_benchmark::add_ground_truth(mbes_ping::PingsT& pings)
 {
-    int rows = 500;
-    int cols = 500;
     for (mbes_ping& ping : pings) {
         gt_track.push_back(ping.pos_);
     }
-    track_img_params(pings, rows, cols);
+    track_img_params(pings);
     add_benchmark(pings, "ground_truth");
     track_img_path = dataset_name + "_benchmark_track_img.png";
 }
 
 void track_error_benchmark::add_ground_truth(PointsT& map_points, PointsT& track_points){
-
-    int rows = 500;
-    int cols = 500;
-
     for(const Eigen::MatrixXd& track_i: track_points){
         for(unsigned int i=0; i<track_i.rows(); i++){
             gt_track.push_back(track_i.row(i));
         }
     }
-    track_img_params(map_points, rows, cols);
+    track_img_params(map_points);
     add_benchmark(map_points, track_points, "ground_truth");
     track_img_path = dataset_name + "_benchmark_track_img.png";
 }

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -654,10 +654,6 @@ mbes_ping::PingsT registration_summary_benchmark::get_submap_pings_index(const m
 }
 
 vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_from_pings(mbes_ping::PingsT& pings){
-
-    int rows = 500;
-    int cols = 500;
-
     double res, minx, miny, x0, y0;
     res = params[0]; minx = params[1]; miny = params[2]; x0 = params[3]; y0 = params[4];
 
@@ -665,10 +661,10 @@ vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_fr
         return sum + int(ping.first_in_file_);
     });
 
-    vector<vector<vector<Eigen::MatrixXd> > > grid_maps(rows);
-    for (int i = 0; i < rows; ++i) {
-        grid_maps[i].resize(cols);
-        for (int j = 0; j < cols; ++j) {
+    vector<vector<vector<Eigen::MatrixXd> > > grid_maps(benchmark_nbr_rows);
+    for (int i = 0; i < benchmark_nbr_rows; ++i) {
+        grid_maps[i].resize(benchmark_nbr_cols);
+        for (int j = 0; j < benchmark_nbr_cols; ++j) {
             grid_maps[i][j].resize(nbr_maps);
         }
     }
@@ -685,7 +681,7 @@ vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_fr
             for (const Eigen::Vector3d& point : iter->beams) {
                 int col = int(x0+res*(point[0]-minx));
                 int row = int(y0+res*(point[1]-miny));
-                if (col >= 0 && col < cols && row >= 0 && row < rows) {
+                if (col >= 0 && col < benchmark_nbr_cols && row >= 0 && row < benchmark_nbr_rows) {
                     grid_maps[row][col][k].conservativeResize(grid_maps[row][col][k].rows()+1, 3);
                     grid_maps[row][col][k].bottomRows<1>() = point.transpose();
                 }
@@ -700,18 +696,15 @@ vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_fr
 
 vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_from_matrices(PointsT& points_maps){
 
-    int rows = 500;
-    int cols = 500;
-
     double res, minx, miny, x0, y0;
     res = params[0]; minx = params[1]; miny = params[2]; x0 = params[3]; y0 = params[4];
 
     int nbr_maps = points_maps.size();
 
-    vector<vector<vector<Eigen::MatrixXd> > > grid_maps(rows);
-    for (int i = 0; i < rows; ++i) {
-        grid_maps[i].resize(cols);
-        for (int j = 0; j < cols; ++j) {
+    vector<vector<vector<Eigen::MatrixXd> > > grid_maps(benchmark_nbr_rows);
+    for (int i = 0; i < benchmark_nbr_rows; ++i) {
+        grid_maps[i].resize(benchmark_nbr_cols);
+        for (int j = 0; j < benchmark_nbr_cols; ++j) {
             grid_maps[i][j].resize(nbr_maps);
         }
     }
@@ -724,7 +717,7 @@ vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_fr
             Eigen::Vector3d point_i = submap_k.row(i);
             int col = int(x0+res*(point_i[0]-minx));
             int row = int(y0+res*(point_i[1]-miny));
-            if (col >= 0 && col < cols && row >= 0 && row < rows) {
+            if (col >= 0 && col < benchmark_nbr_cols && row >= 0 && row < benchmark_nbr_rows) {
                 grid_maps[row][col][k].conservativeResize(grid_maps[row][col][k].rows()+1, 3);
                 grid_maps[row][col][k].bottomRows<1>() = point_i.transpose();
             }


### PR DESCRIPTION
This PR does the following:
- Remove all local definitions of `rows` and `cols` that control the resolution of the benchmark
- Add instance variables `benchmark_nbr_rows` and `benchmark_nbr_cols` to control benchmark resolution instead
- Set the new instance variables in the constructor