### PR TITLE
Add std metrics to benchmark

### DIFF
--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -28,6 +28,8 @@ struct benchmark_range {
 
     benchmark_range(double minx, double miny, double maxx, double maxy) : minx(minx),
         miny(miny), maxx(maxx), maxy(maxy) {};
+
+    benchmark_range() : minx(0), miny(0), maxx(0), maxy(0) {};
 };
 
 struct track_error_benchmark {
@@ -81,6 +83,7 @@ struct track_error_benchmark {
     // Helper functions to track_img_params
     benchmark_range compute_benchmark_range_from_gt_track();
     benchmark_range compute_benchmark_range_from_pings(std_data::mbes_ping::PingsT& pings);
+    benchmark_range compute_benchmark_range_from_pointsT(PointsT& points_maps);
     std::array<double, 5> compute_params_from_benchmark_range(benchmark_range range);
 
     // these 5 functions should be the main way of interfacing with this class
@@ -94,7 +97,7 @@ struct track_error_benchmark {
     void add_ground_truth(PointsT &map_points, PointsT &track_points);
     void add_benchmark(PointsT &maps_points, PointsT &tracks_points, const std::string &name);
 
-    void track_img_params(PointsT& points_maps);
+    void track_img_params(PointsT& points_maps, bool compute_range_from_points = true);
     cv::Mat draw_height_map(PointsT &points_maps);
     std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_pings(std_data::mbes_ping::PingsT& pings);
     std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_matrices(PointsT& points_maps);

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -32,8 +32,8 @@ struct benchmark_range {
     benchmark_range() :
         minx(std::numeric_limits<double>::max()),
         miny(std::numeric_limits<double>::max()),
-        maxx(std::numeric_limits<double>::min()),
-        maxy(std::numeric_limits<double>::min()) {};
+        maxx(std::numeric_limits<double>::lowest()),
+        maxy(std::numeric_limits<double>::lowest()) {};
 };
 
 struct track_error_benchmark {
@@ -96,6 +96,7 @@ struct track_error_benchmark {
     void add_benchmark(std_data::mbes_ping::PingsT& pings, const std::string& name);
     void add_benchmark(std_data::pt_submaps::TransT& trans_corr, std_data::pt_submaps::RotsT& rots_corr, const std::string& name);
     void print_summary();
+
 
     // Overloaded functions to work with input submaps in PointsT format
     void add_ground_truth(PointsT &map_points, PointsT &track_points);

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -85,10 +85,10 @@ struct track_error_benchmark {
     }
 
     // Helper functions to track_img_params
-    benchmark_range compute_benchmark_range_from_gt_track();
-    benchmark_range compute_benchmark_range_from_pings(std_data::mbes_ping::PingsT& pings);
-    benchmark_range compute_benchmark_range_from_pointsT(PointsT& points_maps);
-    std::array<double, 5> compute_params_from_benchmark_range(benchmark_range range);
+    void compute_benchmark_range_from_gt_track(benchmark_range& range);
+    void compute_benchmark_range_from_pings(const std_data::mbes_ping::PingsT& pings, benchmark_range& range);
+    void compute_benchmark_range_from_pointsT(const PointsT& points_maps, benchmark_range& range);
+    std::array<double, 5> compute_params_from_benchmark_range(const benchmark_range& range);
 
     // these 5 functions should be the main way of interfacing with this class
     void add_ground_truth(std_data::mbes_ping::PingsT& pings);

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -59,6 +59,8 @@ struct track_error_benchmark {
     //std::map<std::string, pt_submaps::TransT> tracks;
     std::map<std::string, double> track_rms_errors;
     std::map<std::string, double> consistency_rms_errors;
+    std::map<std::string, double> std_grids_with_hits;
+    std::map<std::string, double> std_grids_with_overlaps;
     double min_consistency_error;
     double max_consistency_error;
     double min_depth_;

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -20,6 +20,16 @@
 
 namespace benchmark {
 
+struct benchmark_range {
+    double minx;
+    double miny;
+    double maxx;
+    double maxy;
+
+    benchmark_range(double minx, double miny, double maxx, double maxy) : minx(minx),
+        miny(miny), maxx(maxx), maxy(maxy) {};
+};
+
 struct track_error_benchmark {
 
     using PointsT = std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >;
@@ -67,6 +77,11 @@ struct track_error_benchmark {
         min_consistency_error = -1.;
         max_consistency_error = -1.;
     }
+
+    // Helper functions to track_img_params
+    benchmark_range compute_benchmark_range_from_gt_track();
+    benchmark_range compute_benchmark_range_from_pings(std_data::mbes_ping::PingsT& pings);
+    std::array<double, 5> compute_params_from_benchmark_range(benchmark_range range);
 
     // these 5 functions should be the main way of interfacing with this class
     void add_ground_truth(std_data::mbes_ping::PingsT& pings);

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -16,6 +16,8 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#include <set>
+
 namespace benchmark {
 
 struct track_error_benchmark {
@@ -84,6 +86,14 @@ struct track_error_benchmark {
     std::pair<double, Eigen::MatrixXd> compute_consistency_error(
             std::vector<std::vector<std::vector<Eigen::MatrixXd> > >& grid_maps);
     cv::Mat draw_error_consistency_map(Eigen::MatrixXd values);
+
+    // Functions for grid std computations and plotting
+    std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::set<int>>>> create_height_and_hits_grid_from_matrices(PointsT& points_maps);
+    double compute_vector_std(const std::vector<double>& vec, double vec_mean);
+    std::pair<double, Eigen::MatrixXd> compute_grid_std(const std::vector<std::vector<std::vector<double>>>& height_grid,
+                                                                 const std::vector<std::vector<std::set<int>>>& hit_by_submaps,
+                                                                 int min_nbr_submap_hits=1);
+    cv::Mat draw_grid(Eigen::MatrixXd);
 
     // Draw heightmap of submaps
     cv::Mat draw_height_submap(PointsT &map_points, PointsT &track_points, const int &submap_number);

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -60,6 +60,7 @@ struct track_error_benchmark {
     //std::map<std::string, pt_submaps::TransT> tracks;
     std::map<std::string, double> track_rms_errors;
     std::map<std::string, double> consistency_rms_errors;
+    std::map<std::string, std::map<int, std::map<bool, double>>> std_metrics;
     std::map<std::string, double> std_grids_with_hits;
     std::map<std::string, double> std_grids_with_overlaps;
     double min_consistency_error;

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -17,6 +17,7 @@
 #include <opencv2/highgui/highgui.hpp>
 
 #include <set>
+#include <fstream>
 
 namespace benchmark {
 
@@ -105,7 +106,7 @@ struct track_error_benchmark {
     void add_benchmark(const PointsT &maps_points, const PointsT &tracks_points, const std::string &name);
 
     void track_img_params(const PointsT& points_maps, bool compute_range_from_points = true);
-    cv::Mat draw_height_map(const PointsT &points_maps);
+    cv::Mat draw_height_map(const PointsT &points_maps, const std::string& name);
     std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_pings(const std_data::mbes_ping::PingsT& pings);
     std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_matrices(const PointsT& points_maps);
     std::pair<double, Eigen::MatrixXd> compute_consistency_error(
@@ -113,12 +114,13 @@ struct track_error_benchmark {
     cv::Mat draw_error_consistency_map(Eigen::MatrixXd values);
 
     // Functions for grid std computations and plotting
-    std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::set<int>>>> create_height_and_hits_grid_from_matrices(const PointsT& points_maps);
     double compute_vector_std(const std::vector<double>& vec, const double vec_mean);
-    std::pair<double, Eigen::MatrixXd> compute_grid_std(const std::vector<std::vector<std::vector<double>>>& height_grid,
-                                                                 const std::vector<std::vector<std::set<int>>>& hit_by_submaps,
-                                                                 int min_nbr_submap_hits=1);
+    std::pair<double, Eigen::MatrixXd> compute_grid_std(const std::vector<std::vector<std::vector<Eigen::MatrixXd>>>& grid_maps,
+        int min_nbr_submap_hits=1, bool compute_mean=true);
     cv::Mat draw_grid(Eigen::MatrixXd values);
+
+    // Other helper functions
+    void write_matrix_to_file(const Eigen::MatrixXd& matrix, const std::string& filename);
 
     // Draw heightmap of submaps
     cv::Mat draw_height_submap(PointsT &map_points, PointsT &track_points, const int &submap_number);

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -90,7 +90,7 @@ struct track_error_benchmark {
     void compute_benchmark_range_from_gt_track(benchmark_range& range);
     void compute_benchmark_range_from_pings(const std_data::mbes_ping::PingsT& pings, benchmark_range& range);
     void compute_benchmark_range_from_pointsT(const PointsT& points_maps, benchmark_range& range);
-    std::array<double, 5> compute_params_from_benchmark_range(const benchmark_range& range);
+    void compute_params_from_benchmark_range(const benchmark_range& range);
 
     // these 5 functions should be the main way of interfacing with this class
     void add_ground_truth(std_data::mbes_ping::PingsT& pings);
@@ -101,24 +101,24 @@ struct track_error_benchmark {
 
 
     // Overloaded functions to work with input submaps in PointsT format
-    void add_ground_truth(PointsT &map_points, PointsT &track_points);
-    void add_benchmark(PointsT &maps_points, PointsT &tracks_points, const std::string &name);
+    void add_ground_truth(const PointsT &map_points, const PointsT &track_points);
+    void add_benchmark(const PointsT &maps_points, const PointsT &tracks_points, const std::string &name);
 
-    void track_img_params(PointsT& points_maps, bool compute_range_from_points = true);
-    cv::Mat draw_height_map(PointsT &points_maps);
-    std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_pings(std_data::mbes_ping::PingsT& pings);
-    std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_matrices(PointsT& points_maps);
+    void track_img_params(const PointsT& points_maps, bool compute_range_from_points = true);
+    cv::Mat draw_height_map(const PointsT &points_maps);
+    std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_pings(const std_data::mbes_ping::PingsT& pings);
+    std::vector<std::vector<std::vector<Eigen::MatrixXd> > > create_grids_from_matrices(const PointsT& points_maps);
     std::pair<double, Eigen::MatrixXd> compute_consistency_error(
-            std::vector<std::vector<std::vector<Eigen::MatrixXd> > >& grid_maps);
+            const std::vector<std::vector<std::vector<Eigen::MatrixXd> > >& grid_maps);
     cv::Mat draw_error_consistency_map(Eigen::MatrixXd values);
 
     // Functions for grid std computations and plotting
-    std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::set<int>>>> create_height_and_hits_grid_from_matrices(PointsT& points_maps);
-    double compute_vector_std(const std::vector<double>& vec, double vec_mean);
+    std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::set<int>>>> create_height_and_hits_grid_from_matrices(const PointsT& points_maps);
+    double compute_vector_std(const std::vector<double>& vec, const double vec_mean);
     std::pair<double, Eigen::MatrixXd> compute_grid_std(const std::vector<std::vector<std::vector<double>>>& height_grid,
                                                                  const std::vector<std::vector<std::set<int>>>& hit_by_submaps,
                                                                  int min_nbr_submap_hits=1);
-    cv::Mat draw_grid(Eigen::MatrixXd);
+    cv::Mat draw_grid(Eigen::MatrixXd values);
 
     // Draw heightmap of submaps
     cv::Mat draw_height_submap(PointsT &map_points, PointsT &track_points, const int &submap_number);

--- a/src/data_tools/include/data_tools/benchmark.h
+++ b/src/data_tools/include/data_tools/benchmark.h
@@ -29,7 +29,11 @@ struct benchmark_range {
     benchmark_range(double minx, double miny, double maxx, double maxy) : minx(minx),
         miny(miny), maxx(maxx), maxy(maxy) {};
 
-    benchmark_range() : minx(0), miny(0), maxx(0), maxy(0) {};
+    benchmark_range() :
+        minx(std::numeric_limits<double>::max()),
+        miny(std::numeric_limits<double>::max()),
+        maxx(std::numeric_limits<double>::min()),
+        maxy(std::numeric_limits<double>::min()) {};
 };
 
 struct track_error_benchmark {

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -295,6 +295,7 @@ std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector
     double res, minx, miny, x0, y0;
     res = params[0]; minx = params[1]; miny = params[2]; x0 = params[3]; y0 = params[4];
 
+    int submap_num = 0;
     for(const Eigen::MatrixXd& submap: points_maps){
         for(unsigned int i = 0; i<submap.rows(); i++){
             Eigen::Vector3d pos = submap.row(i);
@@ -302,9 +303,10 @@ std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector
             int row = int(y0+res*(pos[1]-miny));
             if (col >= 0 && col < benchmark_nbr_cols && row >= 0 && row < benchmark_nbr_rows) {
                 height_grid[row][col].push_back(pos[2]);
-                hit_by_submaps[row][col].insert(i);
+                hit_by_submaps[row][col].insert(submap_num);
             }
         }
+        submap_num += 1;
     }
     return make_pair(height_grid, hit_by_submaps);
 }

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -562,9 +562,11 @@ void track_error_benchmark::add_benchmark(PointsT& maps_points, PointsT& tracks_
     tie(height_grid, hit_by_submaps) = create_height_and_hits_grid_from_matrices(maps_points);
     // std for cells with >= 1 hits (i.e. grids with any data at all)
     tie(average_std_grids_with_data, std_grids_with_data) = compute_grid_std(height_grid, hit_by_submaps, 1);
+    std_grids_with_hits[name] = average_std_grids_with_data;
     cv::imwrite(dataset_name+"_"+name+"_std_grids_with_hits.png", draw_grid(std_grids_with_data));
     // std for cells with >= 2 hits (i.e. grids with overlap)
     tie(average_std_grids_with_overlap, std_grids_with_overlap) = compute_grid_std(height_grid, hit_by_submaps, 2);
+    std_grids_with_overlaps[name] = average_std_grids_with_overlap;
     cv::imwrite(dataset_name+"_"+name+"_std_grids_with_overlap.png", draw_grid(std_grids_with_overlap));
 
     cout << " -------------- " << endl;
@@ -639,6 +641,12 @@ void track_error_benchmark::print_summary()
     }
     for (const pair<string, double>& p : consistency_rms_errors) {
         cout << p.first << " RMS consistency error: " << p.second << endl;
+    }
+    for (const pair<string, double>& p: std_grids_with_hits) {
+        cout << p.first << " Std grids with hits (1): " << p.second << endl;
+    }
+    for (const pair<string, double>& p: std_grids_with_overlaps) {
+        cout << p.first << " Std grids with overlap (2): " << p.second << endl;
     }
     for (const pair<string, string>& p : error_img_paths) {
         cout << p.first << " consistency image path: " << p.second << endl;

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -51,8 +51,10 @@ benchmark_range track_error_benchmark::compute_benchmark_range_from_gt_track() {
 }
 
 benchmark_range track_error_benchmark::compute_benchmark_range_from_pointsT(PointsT& points_maps) {
-    double minx, miny = std::numeric_limits<double>::max();
-    double maxx, maxy = std::numeric_limits<double>::min();
+    double minx = std::numeric_limits<double>::max();
+    double miny = std::numeric_limits<double>::max();
+    double maxx = std::numeric_limits<double>::min();
+    double maxy = std::numeric_limits<double>::min();
 
     for (auto point_cloud : points_maps) {
         auto min_coeff = point_cloud.colwise().minCoeff();

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -677,15 +677,6 @@ void track_error_benchmark::print_summary()
     for (const pair<string, double>& p : consistency_rms_errors) {
         cout << p.first << " RMS consistency error: " << p.second << endl;
     }
-    for (const pair<string, double>& p: std_grids_with_hits) {
-        cout << p.first << " Std grids with hits (1): " << p.second << endl;
-    }
-    for (const pair<string, double>& p: std_grids_with_overlaps) {
-        cout << p.first << " Std grids with overlap (2): " << p.second << endl;
-    }
-    for (const pair<string, string>& p : error_img_paths) {
-        cout << p.first << " consistency image path: " << p.second << endl;
-    }
     cout << "Max consistency error: " << max_consistency_error << endl;
     cout << "Min consistency error: " << min_consistency_error << endl;
 }

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -50,6 +50,23 @@ benchmark_range track_error_benchmark::compute_benchmark_range_from_gt_track() {
     return benchmark_range(minx, miny, maxx, maxy);
 }
 
+benchmark_range track_error_benchmark::compute_benchmark_range_from_pointsT(PointsT& points_maps) {
+    double minx, miny = std::numeric_limits<double>::max();
+    double maxx, maxy = std::numeric_limits<double>::min();
+
+    for (auto point_cloud : points_maps) {
+        auto min_coeff = point_cloud.colwise().minCoeff();
+        auto max_coeff = point_cloud.colwise().maxCoeff();
+
+        minx = std::min(minx, min_coeff[0]);
+        miny = std::min(miny, min_coeff[1]);
+
+        maxx = std::max(maxx, max_coeff[0]);
+        maxy = std::max(maxy, max_coeff[1]);
+    }
+    return benchmark_range(minx, miny, maxx, maxy);
+}
+
 array<double, 5> track_error_benchmark::compute_params_from_benchmark_range(benchmark_range range) {
     cout << "Min X: " << range.minx << ", Max X: " << range.maxx << ", Min Y: " << range.miny << ", Max Y: " << range.maxy << endl;
 
@@ -76,9 +93,16 @@ void track_error_benchmark::track_img_params(mbes_ping::PingsT& pings)
 }
 
 
-void track_error_benchmark::track_img_params(PointsT& points_maps)
+void track_error_benchmark::track_img_params(PointsT& points_maps, bool compute_range_from_points)
 {
-    benchmark_range range = compute_benchmark_range_from_gt_track();
+    benchmark_range range;
+    // Compute range from the given PointsT& points_maps directly if the flag is set to true
+    // Otherwise compute range from the gt_track set in the add_groundtruth method...
+    if (compute_range_from_points) {
+        range = compute_benchmark_range_from_pointsT(points_maps);
+    } else {
+        range = compute_benchmark_range_from_gt_track();
+    }
     params = compute_params_from_benchmark_range(range);
     track_img = cv::Mat(benchmark_nbr_rows, benchmark_nbr_cols, CV_8UC3, cv::Scalar(255, 255, 255));
 }

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -71,7 +71,7 @@ void track_error_benchmark::compute_benchmark_range_from_pointsT(const PointsT& 
     range.maxy = maxy;
 }
 
-array<double, 5> track_error_benchmark::compute_params_from_benchmark_range(const benchmark_range& range) {
+void track_error_benchmark::compute_params_from_benchmark_range(const benchmark_range& range) {
     cout << "Min X: " << range.minx << ", Max X: " << range.maxx << ", Min Y: " << range.miny << ", Max Y: " << range.maxy << endl;
 
     double xres = double(benchmark_nbr_cols)/(range.maxx - range.minx);
@@ -84,7 +84,11 @@ array<double, 5> track_error_benchmark::compute_params_from_benchmark_range(cons
 
     cout << xres << ", " << yres << endl;
 
-    return array<double, 5>{res, range.minx, range.miny, x0, y0};
+    params[0] = res;
+    params[1] = range.minx;
+    params[2] = range.miny;
+    params[3] = x0;
+    params[4] = y0;
 }
 
 
@@ -93,12 +97,12 @@ void track_error_benchmark::track_img_params(mbes_ping::PingsT& pings)
 {
     benchmark_range range;
     compute_benchmark_range_from_pings(pings, range);
-    params = compute_params_from_benchmark_range(range);
+    compute_params_from_benchmark_range(range);
     track_img = cv::Mat(benchmark_nbr_rows, benchmark_nbr_cols, CV_8UC3, cv::Scalar(255, 255, 255));
 }
 
 
-void track_error_benchmark::track_img_params(PointsT& points_maps, bool compute_range_from_points)
+void track_error_benchmark::track_img_params(const PointsT& points_maps, bool compute_range_from_points)
 {
     benchmark_range range;
     // Compute range from the given PointsT& points_maps directly if the flag is set to true
@@ -108,7 +112,7 @@ void track_error_benchmark::track_img_params(PointsT& points_maps, bool compute_
     } else {
         compute_benchmark_range_from_gt_track(range);
     }
-    params = compute_params_from_benchmark_range(range);
+    compute_params_from_benchmark_range(range);
     track_img = cv::Mat(benchmark_nbr_rows, benchmark_nbr_cols, CV_8UC3, cv::Scalar(255, 255, 255));
 }
 
@@ -314,7 +318,7 @@ void track_error_benchmark::map_draw_params(PointsT& map_points, PointsT& track_
 }
 
 
-std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::set<int>>>> track_error_benchmark::create_height_and_hits_grid_from_matrices(PointsT& points_maps) {
+std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::set<int>>>> track_error_benchmark::create_height_and_hits_grid_from_matrices(const PointsT& points_maps) {
     std::vector<std::vector<std::vector<double>>> height_grid(benchmark_nbr_rows);
     std::vector<std::vector<std::set<int>>> hit_by_submaps(benchmark_nbr_rows);
     for (int i = 0; i < benchmark_nbr_rows; ++i) {
@@ -341,7 +345,7 @@ std::pair<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector
     return make_pair(height_grid, hit_by_submaps);
 }
 
-double track_error_benchmark::compute_vector_std(const std::vector<double>& vec, double vec_mean) {
+double track_error_benchmark::compute_vector_std(const std::vector<double>& vec, const double vec_mean) {
     double vec_std = 0;
     for (auto i : vec) {
         vec_std += pow(i - vec_mean, 2);
@@ -374,7 +378,7 @@ std::pair<double, Eigen::MatrixXd> track_error_benchmark::compute_grid_std(const
     return make_pair(average_std, standard_deviation);
 }
 
-cv::Mat track_error_benchmark::draw_height_map(PointsT& points_maps)
+cv::Mat track_error_benchmark::draw_height_map(const PointsT& points_maps)
 {
     Eigen::MatrixXd means(benchmark_nbr_rows, benchmark_nbr_cols); means.setZero();
     Eigen::MatrixXd counts(benchmark_nbr_rows, benchmark_nbr_cols); counts.setZero();
@@ -520,7 +524,7 @@ void track_error_benchmark::add_ground_truth(mbes_ping::PingsT& pings)
     track_img_path = dataset_name + "_benchmark_track_img.png";
 }
 
-void track_error_benchmark::add_ground_truth(PointsT& map_points, PointsT& track_points){
+void track_error_benchmark::add_ground_truth(const PointsT& map_points, const PointsT& track_points){
     for(const Eigen::MatrixXd& track_i: track_points){
         for(unsigned int i=0; i<track_i.rows(); i++){
             gt_track.push_back(track_i.row(i));
@@ -536,7 +540,7 @@ void track_error_benchmark::add_initial(mbes_ping::PingsT& pings)
     input_pings = pings;
 }
 
-void track_error_benchmark::add_benchmark(PointsT& maps_points, PointsT& tracks_points,
+void track_error_benchmark::add_benchmark(const PointsT& maps_points, const PointsT& tracks_points,
                                           const std::string& name){
     cv::Mat error_img;
     Eigen::MatrixXd error_vals;
@@ -760,7 +764,7 @@ mbes_ping::PingsT registration_summary_benchmark::get_submap_pings_index(const m
     return pings_i;
 }
 
-vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_from_pings(mbes_ping::PingsT& pings){
+vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_from_pings(const mbes_ping::PingsT& pings){
     double res, minx, miny, x0, y0;
     res = params[0]; minx = params[1]; miny = params[2]; x0 = params[3]; y0 = params[4];
 
@@ -801,7 +805,7 @@ vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_fr
     return grid_maps;
 }
 
-vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_from_matrices(PointsT& points_maps){
+vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_from_matrices(const PointsT& points_maps){
 
     double res, minx, miny, x0, y0;
     res = params[0]; minx = params[1]; miny = params[2]; x0 = params[3]; y0 = params[4];
@@ -818,10 +822,10 @@ vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_fr
 
     int k = 0;
     // For each submap
-    for (Eigen::MatrixXd& submap_k: points_maps) {
+    for (const Eigen::MatrixXd& submap_k: points_maps) {
         // For each beam in submap k
         for(unsigned int i=0; i<submap_k.rows(); i++){
-            Eigen::Vector3d point_i = submap_k.row(i);
+            const Eigen::Vector3d point_i = submap_k.row(i);
             int col = int(x0+res*(point_i[0]-minx));
             int row = int(y0+res*(point_i[1]-miny));
             if (col >= 0 && col < benchmark_nbr_cols && row >= 0 && row < benchmark_nbr_rows) {
@@ -835,7 +839,7 @@ vector<vector<vector<Eigen::MatrixXd> > > track_error_benchmark::create_grids_fr
 }
 
 std::pair<double, Eigen::MatrixXd> track_error_benchmark::compute_consistency_error(
-        vector<vector<vector<Eigen::MatrixXd> > >& grid_maps)
+        const vector<vector<vector<Eigen::MatrixXd> > >& grid_maps)
 {
     int nbr_maps = grid_maps[0][0].size();
     assert(("grid_maps.size() == benchmark_nbr_rows", grid_maps.size() == benchmark_nbr_rows));
@@ -844,6 +848,7 @@ std::pair<double, Eigen::MatrixXd> track_error_benchmark::compute_consistency_er
 
     // Subsample grids
     Eigen::MatrixXd values(benchmark_nbr_rows, benchmark_nbr_cols); values.setZero();
+/*
     //Eigen::MatrixXd counts(benchmark_nbr_rows, benchmark_nbr_cols); counts.setZero();
     for (int i = 0; i < benchmark_nbr_rows; ++i) {
         for (int j = 0; j < benchmark_nbr_cols; ++j) {
@@ -863,6 +868,7 @@ std::pair<double, Eigen::MatrixXd> track_error_benchmark::compute_consistency_er
             }
         }
     }
+*/
 
     // For each grid
     double value_sum = 0.;

--- a/src/data_tools/src/benchmark.cpp
+++ b/src/data_tools/src/benchmark.cpp
@@ -53,8 +53,8 @@ benchmark_range track_error_benchmark::compute_benchmark_range_from_gt_track() {
 benchmark_range track_error_benchmark::compute_benchmark_range_from_pointsT(PointsT& points_maps) {
     double minx = std::numeric_limits<double>::max();
     double miny = std::numeric_limits<double>::max();
-    double maxx = std::numeric_limits<double>::min();
-    double maxy = std::numeric_limits<double>::min();
+    double maxx = std::numeric_limits<double>::lowest();
+    double maxy = std::numeric_limits<double>::lowest();
 
     for (auto point_cloud : points_maps) {
         auto min_coeff = point_cloud.colwise().minCoeff();
@@ -65,6 +65,7 @@ benchmark_range track_error_benchmark::compute_benchmark_range_from_pointsT(Poin
 
         maxx = std::max(maxx, max_coeff[0]);
         maxy = std::max(maxy, max_coeff[1]);
+
     }
     return benchmark_range(minx, miny, maxx, maxy);
 }

--- a/src/pydata_tools/src/pybenchmark.cpp
+++ b/src/pydata_tools/src/pybenchmark.cpp
@@ -25,9 +25,9 @@ PYBIND11_MODULE(benchmark, m) {
         .def(py::init<const std::string&>(), "Constructor, takes the dataset name")
         .def(py::init<>(), "Constructor, default dataset name 'default'")
         .def("add_ground_truth", (void (track_error_benchmark::*)(std_data::mbes_ping::PingsT&) ) &track_error_benchmark::add_ground_truth, "Add the ground truth dataset, need to call this before add_benchmark")
-        .def("add_ground_truth", (void (track_error_benchmark::*)(std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >&, std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >& ) ) &track_error_benchmark::add_ground_truth, "Add the ground truth dataset, need to call this before add_benchmark")
+        .def("add_ground_truth", (void (track_error_benchmark::*)(const std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >&, const std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >& ) ) &track_error_benchmark::add_ground_truth, "Add the ground truth dataset, need to call this before add_benchmark")
         .def("add_benchmark", (void (track_error_benchmark::*)(std_data::mbes_ping::PingsT&, const std::string&) ) &track_error_benchmark::add_benchmark, "Add a benchmark from std_data::mbes_ping::PingsT")
-        .def("add_benchmark", (void (track_error_benchmark::*)(std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >&, std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >&, const std::string&) ) &track_error_benchmark::add_benchmark, "Add a benchmark from PointsT")
+        .def("add_benchmark", (void (track_error_benchmark::*)(const std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >&, const std::vector<Eigen::MatrixXd, Eigen::aligned_allocator<Eigen::MatrixXd> >&, const std::string&) ) &track_error_benchmark::add_benchmark, "Add a benchmark from PointsT")
         .def("print_summary", (void (track_error_benchmark::*)() ) &track_error_benchmark::print_summary, "Prints summary of benchmarking results");
 
     // from http://alexsm.com/pybind11-buffer-protocol-opencv-to-numpy/


### PR DESCRIPTION
# What has changed?
- Implement new metric for benchmarking a grid: the new metrics computes the z-value standard deviation of all points falling onto one particular grid cell
- Refactor parts of `benchmark.cpp` for benchmark range computations
- Add new ways of computing `benchmark_range`: we can now compute the range of a benchmark straight from the provided point clouds (previous implementations extract the `benchmark_range` from `gt_track`, which required the benchmarked point clouds to be associated with an AUV trajectory)0 
- Add keyword `const` to function parameters that can be const

# Side effects?
- The APIs `add_benchmark` for `PointsT` and `std::mbes_pings::PingsT` now function slightly differently:
  - For `PointsT`, i.e. for point cloud submaps, it now computes three metrics: RMS consistency error, std on all grid cells, std on cells with overlaps
  - For `std::mbes_pings::PingsT`, i.e. for raw data from the MBES, it still only computes the RMS consistency error
- Why the side effects happen: I have currently no use case for the API with `std::mbes_pings::PingsT` right now, so I haven't looked at implementing the same changes to it. Besides, the `benchmark` API implementation contains a lot of code duplication, I think the best thing to do is to clean up the code and refactor them properly... (Though this is not in my current TODO list.)